### PR TITLE
Session struct (de)serialization improvements

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -2,3 +2,6 @@ alias Charon.{Internal, SessionPlugs, TokenPlugs, Utils}
 alias Charon.Models.{Session, Tokens}
 alias Charon.TokenFactory.SymmetricJwt
 alias Charon.SessionStore.RedisStore
+alias Charon.Config, as: CharonConfig
+
+charon_config = CharonConfig.from_enum(token_issuer: "local")

--- a/lib/charon/models/session.ex
+++ b/lib/charon/models/session.ex
@@ -2,26 +2,29 @@ defmodule Charon.Models.Session do
   @moduledoc """
   A session.
   """
+  @enforce_keys [:expires_at]
   defstruct [
     :created_at,
     :id,
-    :type,
     :user_id,
     :expires_at,
     :refresh_token_id,
     :refreshed_at,
-    extra_payload: %{}
+    type: :full,
+    extra_payload: %{},
+    version: 1
   ]
 
   @type t :: %__MODULE__{
           created_at: integer,
-          expires_at: integer | nil,
+          expires_at: integer | :infinite,
           extra_payload: map(),
           id: String.t(),
           refresh_token_id: String.t(),
           refreshed_at: integer,
           type: atom(),
-          user_id: pos_integer | binary()
+          user_id: pos_integer | binary(),
+          version: pos_integer
         }
 
   alias Charon.{Config, Internal}
@@ -45,10 +48,51 @@ defmodule Charon.Models.Session do
     struct!(__MODULE__, enum)
   end
 
+  @doc """
+  Serialize a session.
+  """
+  @spec serialize(struct) :: binary
+  def serialize(session) do
+    session |> Map.from_struct() |> :erlang.term_to_binary()
+  end
+
+  @doc """
+  Deserialize a session, without breaking for structural changes in the session struct.
+
+  ## DocTests
+
+      @charon_config Charon.Config.from_enum(token_issuer: "local")
+
+      # serialization is reversible
+      iex> %Session{} = @charon_config |> new() |> serialize() |> deserialize()
+
+      # old version - without the :version field - is deserialized without error
+      iex> serialized = "g3QAAAAIZAAKY3JlYXRlZF9hdGJjdlx6ZAAKZXhwaXJlc19hdGJlV4/6ZAANZXh0cmFfcGF5bG9hZHQAAAAAZAACaWRtAAAAFk1xMk0xRUlJUTFKV1dMTEZBSnk2YndkABByZWZyZXNoX3Rva2VuX2lkbQAAAANhYmNkAAxyZWZyZXNoZWRfYXRhAGQABHR5cGVkAARmdWxsZAAHdXNlcl9pZGEB"
+      iex> serialized |> Base.decode64!() |> deserialize()
+      %Charon.Models.Session{created_at: 1668701306, id: "Mq2M1EIIQ1JWWLLFAJy6bw", user_id: 1, expires_at: 1700237306, refresh_token_id: "abc", refreshed_at: 0, type: :full, extra_payload: %{}, version: 1}
+
+      # old version - with :expires_at = nil - is deserialized without error
+      iex> %Session{expires_at: :infinite} = @charon_config |> new(expires_at: nil) |> serialize() |> deserialize()
+
+  """
+  @spec deserialize(binary) :: struct
+  def deserialize(binary) do
+    binary
+    |> :erlang.binary_to_term()
+    |> case do
+      session = %{expires_at: nil} -> %{session | expires_at: :infinite}
+      session -> session
+    end
+    |> case do
+      map -> struct!(__MODULE__, map)
+    end
+  end
+
   ###########
   # Private #
   ###########
 
-  defp expires_at(%{session_ttl: :infinite}, _now), do: nil
+  defp expires_at(%{session_ttl: :infinite}, _now), do: :infinite
+  defp expires_at(%{session_ttl: nil}, _now), do: :infinite
   defp expires_at(%{session_ttl: ttl}, now), do: ttl + now
 end

--- a/lib/charon/session_plugs.ex
+++ b/lib/charon/session_plugs.ex
@@ -64,7 +64,7 @@ defmodule Charon.SessionPlugs do
 
       # renews session if present in conn, updating only refresh_token_id, refreshed_at
       # existing session's user id will not change despite attempted override
-      iex> old_session = %Session{user_id: 43, id: "a"}
+      iex> old_session = %Session{user_id: 43, id: "a", expires_at: :infinite}
       iex> conn = conn()
       ...> |> Conn.put_private(@session, old_session)
       ...> |> Utils.set_token_signature_transport(:bearer)
@@ -260,7 +260,7 @@ defmodule Charon.SessionPlugs do
 
   # this ensures that a token's exp claim never outlives its session
   defp calc_ttl(session, now, max_ttl)
-  defp calc_ttl(%{expires_at: nil}, _now, max_ttl), do: max_ttl
+  defp calc_ttl(%{expires_at: :infinite}, _now, max_ttl), do: max_ttl
   defp calc_ttl(%{expires_at: session_exp}, now, max_ttl), do: min(session_exp - now, max_ttl)
 
   defp transport_tokens(

--- a/lib/charon/token_plugs.ex
+++ b/lib/charon/token_plugs.ex
@@ -352,10 +352,9 @@ defmodule Charon.TokenPlugs do
 
   ## Doctests
 
-      iex> command(["SET", session_key("a", 1), :erlang.term_to_binary(%{stored: :session})])
+      iex> command(["SET", session_key("a", 1), %Session{expires_at: 0} |> Session.serialize()])
       iex> conn = conn() |> put_private(@bearer_token_payload, %{"sid" => "a", "sub" => 1})
-      iex> conn |> load_session(@config) |> Internal.get_private(@session)
-      %{stored: :session}
+      iex> %Session{} = conn |> load_session(@config) |> Internal.get_private(@session)
 
       # token payload must contain "sub" and "sid" claims
       iex> conn = conn() |> put_private(@bearer_token_payload, 1)

--- a/test/charon/models/session_test.exs
+++ b/test/charon/models/session_test.exs
@@ -1,0 +1,9 @@
+defmodule Charon.Models.SessionTest do
+  use ExUnit.Case, async: true
+  alias Charon.Models.Session
+  import Session
+
+  @charon_config Charon.Config.from_enum(token_issuer: "local")
+
+  doctest Session
+end

--- a/test/charon/session_plugs_test.exs
+++ b/test/charon/session_plugs_test.exs
@@ -9,13 +9,6 @@ defmodule Charon.SessionPlugsTest do
   alias Charon.TestRedix
   import TestRedix, only: [command: 1]
 
-  @sid "a"
-  @uid 426
-  @user_session %{id: @sid, user_id: @uid}
-  @serialized :erlang.term_to_binary(@user_session)
-
-  def get_secret(), do: "supersecret"
-
   @config Charon.Config.from_enum(
             token_issuer: "my_test_app",
             optional_modules: %{
@@ -23,6 +16,13 @@ defmodule Charon.SessionPlugsTest do
               Charon.SessionStore.RedisStore => %{redix_module: TestRedix}
             }
           )
+
+  @sid "a"
+  @uid 426
+  @user_session Session.new(@config, id: @sid, user_id: @uid)
+  @serialized Session.serialize(@user_session)
+
+  def get_secret(), do: "supersecret"
 
   setup_all do
     TestRedix.init()
@@ -59,7 +59,7 @@ defmodule Charon.SessionPlugsTest do
         |> upsert_session(%{@config | session_ttl: :infinite})
 
       session = Utils.get_session(conn)
-      assert session.expires_at == nil
+      assert session.expires_at == :infinite
     end
 
     test "should store sessions with refresh ttl, not session ttl" do

--- a/test/charon/session_store/redis_store_test.exs
+++ b/test/charon/session_store/redis_store_test.exs
@@ -1,17 +1,19 @@
 defmodule Charon.SessionStore.RedisStoreTest do
   use ExUnit.Case
   alias Charon.SessionStore.RedisStore
+  alias Charon.Models.Session
   import Charon.{TestUtils, Internal}
   alias Charon.TestRedix
   import TestRedix, only: [command: 1]
 
   @config %{
+    session_ttl: :infinite,
     optional_modules: %{RedisStore => RedisStore.Config.from_enum(redix_module: TestRedix)}
   }
   @sid "a"
   @uid 426
-  @user_session %{id: @sid, user_id: @uid}
-  @serialized :erlang.term_to_binary(@user_session)
+  @user_session Session.new(@config, id: @sid, user_id: @uid)
+  @serialized Session.serialize(@user_session)
   @ttl 10
 
   setup_all do

--- a/test/charon/token_plugs_unit_test.exs
+++ b/test/charon/token_plugs_unit_test.exs
@@ -10,6 +10,7 @@ defmodule Charon.TokenPlugsTest do
   import TestRedix, only: [command: 1]
   import TokenPlugs
   alias TokenPlugs.PutAssigns
+  alias Charon.Models.Session
 
   @config Charon.Config.from_enum(
             token_issuer: "my_test_app",


### PR DESCRIPTION
Changes:
 - (de)serialize sessions in a backwards-compatible way
 - use `:infinite` instead of `nil` for never-expiring session's `expires_at` value