### PR TITLE
Behaviours TokenFactory and SessionStore now generically callable

### DIFF
--- a/lib/charon/session_store.ex
+++ b/lib/charon/session_store.ex
@@ -1,51 +1,24 @@
 defmodule Charon.SessionStore do
   @moduledoc """
-  Behaviour definition of a persistent session store.
-  The implementation is expected to handle cleanup of expired entries.
-
-  All three callbacks can use only a session ID, and ignore the user ID that is passed in as well, because a session ID is a unique 128-bits binary by itself.
-
-  However, not ignoring the user ID enables the usecase where all sessions for a user are fetched or deleted (the optional callbacks), for example, so there are benefits to storing sessions per user.
+  Entrypoint for `Charon.SessionStore.Behaviour` implementation.
+  All functions delegate to the configured module.
   """
-  alias Charon.Session
-  alias Charon.Config
+  @behaviour __MODULE__.Behaviour
 
-  @optional_callbacks [get_all: 2, delete_all: 2]
+  @impl true
+  def delete(session_id, user_id, config),
+    do: config.session_store_module.delete(session_id, user_id, config)
 
-  @doc """
-  Delete session with id `session_id` for user with id `user_id`.
+  @impl true
+  def get(session_id, user_id, config),
+    do: config.session_store_module.get(session_id, user_id, config)
 
-  Implementations may choose to ignore `user_id`, since `session_id` is unique by itself.
-  """
-  @callback delete(session_id :: binary, user_id :: binary | integer(), config :: Config.t()) ::
-              :ok | {:error, binary}
+  @impl true
+  def get_all(user_id, config), do: config.session_store_module.get_all(user_id, config)
 
-  @doc """
-  Insert or update #{Session} `session`, with time-to-live `ttl`.
+  @impl true
+  def upsert(session, ttl, config), do: config.session_store_module.upsert(session, ttl, config)
 
-  The `session_id` and `user_id` are taken from the `session` struct.
-  Implementations may choose to ignore `user_id`, since `session_id` is unique by itself.
-  """
-  @callback upsert(session :: Session.t(), ttl :: pos_integer(), config :: Config.t()) ::
-              :ok | {:error, binary}
-
-  @doc """
-  Get session with id `session_id` for user with id `user_id`.
-
-  Implementations may choose to ignore `user_id`, since `session_id` is unique by itself.
-  """
-  @callback get(session_id :: binary, user_id :: binary | integer(), config :: Config.t()) ::
-              Session.t() | nil | {:error, binary}
-
-  @doc """
-  Get all sessions for the user with id `user_id`.
-  """
-  @callback get_all(user_id :: binary | integer, config :: Config.t()) ::
-              [Session.t()] | {:error, binary}
-
-  @doc """
-  Delete all sessions for the user with id `user_id`.
-  """
-  @callback delete_all(user_id :: binary | integer, config :: Config.t()) ::
-              :ok | {:error, binary}
+  @impl true
+  def delete_all(user_id, config), do: config.session_store_module.delete_all(user_id, config)
 end

--- a/lib/charon/session_store/behaviour.ex
+++ b/lib/charon/session_store/behaviour.ex
@@ -1,0 +1,51 @@
+defmodule Charon.SessionStore.Behaviour do
+  @moduledoc """
+  Behaviour definition of a persistent session store.
+  The implementation is expected to handle cleanup of expired entries.
+
+  All three callbacks can use only a session ID, and ignore the user ID that is passed in as well, because a session ID is a unique 128-bits binary by itself.
+
+  However, not ignoring the user ID enables the usecase where all sessions for a user are fetched or deleted (the optional callbacks), for example, so there are benefits to storing sessions per user.
+  """
+  alias Charon.Session
+  alias Charon.Config
+
+  @optional_callbacks [get_all: 2, delete_all: 2]
+
+  @doc """
+  Delete session with id `session_id` for user with id `user_id`.
+
+  Implementations may choose to ignore `user_id`, since `session_id` is unique by itself.
+  """
+  @callback delete(session_id :: binary, user_id :: binary | integer(), config :: Config.t()) ::
+              :ok | {:error, binary}
+
+  @doc """
+  Insert or update `session`, with time-to-live `ttl`.
+
+  The `session_id` and `user_id` are taken from the `session` struct.
+  Implementations may choose to ignore `user_id`, since `session_id` is unique by itself.
+  """
+  @callback upsert(session :: Session.t(), ttl :: pos_integer(), config :: Config.t()) ::
+              :ok | {:error, binary}
+
+  @doc """
+  Get session with id `session_id` for user with id `user_id`.
+
+  Implementations may choose to ignore `user_id`, since `session_id` is unique by itself.
+  """
+  @callback get(session_id :: binary, user_id :: binary | integer(), config :: Config.t()) ::
+              Session.t() | nil | {:error, binary}
+
+  @doc """
+  Get all sessions for the user with id `user_id`.
+  """
+  @callback get_all(user_id :: binary | integer, config :: Config.t()) ::
+              [Session.t()] | {:error, binary}
+
+  @doc """
+  Delete all sessions for the user with id `user_id`.
+  """
+  @callback delete_all(user_id :: binary | integer, config :: Config.t()) ::
+              :ok | {:error, binary}
+end

--- a/lib/charon/session_store/dummy_store.ex
+++ b/lib/charon/session_store/dummy_store.ex
@@ -2,7 +2,7 @@ defmodule Charon.SessionStore.DummyStore do
   @moduledoc """
   A dummy session store that can be used if fully stateless tokens are desired.
   """
-  @behaviour Charon.SessionStore
+  @behaviour Charon.SessionStore.Behaviour
 
   @impl true
   def get(_session_id, _user_id, _config), do: nil

--- a/lib/charon/session_store/redis_store.ex
+++ b/lib/charon/session_store/redis_store.ex
@@ -30,7 +30,7 @@ defmodule Charon.SessionStore.RedisStore do
   Session keys slowly accumulate in Redis when using this store.
   It provides a `cleanup/1` that should run periodically.
   """
-  @behaviour Charon.SessionStore
+  @behaviour Charon.SessionStore.Behaviour
   alias Charon.Config
   alias Charon.Internal
   alias Charon.Models.Session

--- a/lib/charon/token_factory.ex
+++ b/lib/charon/token_factory.ex
@@ -1,24 +1,13 @@
 defmodule Charon.TokenFactory do
   @moduledoc """
-  Behaviour for token-signing modules.
-
-  Note that the token payload must be returned as a map with string keys on verification.
-  When the payload is serialized as JSON, this happens automatically.
-  However, when Erlang term format is used, this is not the case.
+  Entrypoint for `Charon.TokenFactory.Behaviour` implementation.
+  All functions delegate to the configured module.
   """
-  alias Charon.Config
+  @behaviour __MODULE__.Behaviour
 
-  @doc """
-  Create a new token with the provided payload and a valid signature.
-  """
-  @callback sign(payload :: %{required(String.t()) => any()}, config :: Config.t()) ::
-              {:ok, String.t()} | {:error, String.t()}
+  @impl true
+  def sign(payload, config), do: config.token_factory_module.sign(payload, config)
 
-  @doc """
-  Verify that the signature matches the token's header and payload, and decode the payload.
-
-  Must return a map of string keys.
-  """
-  @callback verify(token :: String.t(), config :: Config.t()) ::
-              {:ok, %{required(String.t()) => any()}} | {:error, String.t()}
+  @impl true
+  def verify(token, config), do: config.token_factory_module.verify(token, config)
 end

--- a/lib/charon/token_factory/behaviour.ex
+++ b/lib/charon/token_factory/behaviour.ex
@@ -1,0 +1,24 @@
+defmodule Charon.TokenFactory.Behaviour do
+  @moduledoc """
+  Behaviour for token-signing modules.
+
+  Note that the token payload must be returned as a map with string keys on verification.
+  When the payload is serialized as JSON, this happens automatically.
+  However, when Erlang term format is used, this is not the case.
+  """
+  alias Charon.Config
+
+  @doc """
+  Create a new token with the provided payload and a valid signature.
+  """
+  @callback sign(payload :: %{required(String.t()) => any()}, config :: Config.t()) ::
+              {:ok, String.t()} | {:error, String.t()}
+
+  @doc """
+  Verify that the signature matches the token's header and payload, and decode the payload.
+
+  Must return a map of string keys.
+  """
+  @callback verify(token :: String.t(), config :: Config.t()) ::
+              {:ok, %{required(String.t()) => any()}} | {:error, String.t()}
+end

--- a/lib/charon/token_factory/symmetric_jwt.ex
+++ b/lib/charon/token_factory/symmetric_jwt.ex
@@ -63,7 +63,7 @@ defmodule Charon.TokenFactory.SymmetricJwt do
       iex> config = %{optional_modules: %{SymmetricJwt => SymmetricJwt.Config.from_enum(get_secret: fn -> :crypto.strong_rand_bytes(32) end)}}
       iex> {:error, "signature invalid"} = verify(token, config)
   """
-  @behaviour Charon.TokenFactory
+  @behaviour Charon.TokenFactory.Behaviour
 
   @encoding_opts padding: false
   @alg_to_header_map %{


### PR DESCRIPTION
Separating the behaviour and the "entrypoint module" allows for a cleaner lib API, without having to do `config.session_store_module`, for example.