### PR TITLE
Cycle token generation in `upsert_session/3`, clean up & clarify code

### DIFF
--- a/lib/charon/internal/constants.ex
+++ b/lib/charon/internal/constants.ex
@@ -6,13 +6,14 @@ defmodule Charon.Internal.Constants do
       @auth_error :charon_auth_error
       @bearer_token :charon_bearer_token
       @bearer_token_payload :charon_bearer_token_payload
+      @cycle_token_generation :charon_cycle_token_generation
       @refresh_token_payload :charon_refresh_token_payload
+      @resp_cookies :charon_resp_cookies
       @session :charon_session
       @session_id :charon_session_id
       @token_signature_transport :charon_token_signature_transport
       @tokens :charon_tokens
       @user_id :charon_user_id
-      @resp_cookies :charon_resp_cookies
     end
   end
 end

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -18,11 +18,11 @@ defmodule Charon.TestUtils do
       created_at: 0,
       expires_at: 0,
       id: "a",
-      prev_t_gen_fresh_at: 0,
+      prev_tokens_fresh_from: 0,
       refresh_expires_at: 0,
       refresh_token_id: "b",
       refreshed_at: 0,
-      t_gen_fresh_at: 0,
+      tokens_fresh_from: 0,
       user_id: 1
     }
     |> Map.merge(Map.new(overrides))


### PR DESCRIPTION
Currently, when logging the session after `verify_token_fresh/2` returns a "token stale" error, the values used to determine freshness have already been cycled by the plug. This is confusing and makes debugging more difficult. Now determining if a token generation cycle happens is determined by the plug, but the actual cycling takes place in `upsert_session/3`, which is much cleaner and avoids this problem. The code has also been simplified, and the quite horribly named session field `t_gen_fresh_at` has been renamed to `tokens_fresh_from`.