### PR TITLE
Set version to 2.0 in readme instead of injecting specific version

### DIFF
--- a/.github/workflows/cd_workflow.yml
+++ b/.github/workflows/cd_workflow.yml
@@ -23,11 +23,6 @@ jobs:
           restore-keys: |
             deps-cache-
 
-      - name: Set version in readme
-        uses: weareyipyip/set-version-action@v2
-        with:
-          source: tag
-          file_path: README.md
       - name: Set version in mix.exs
         uses: weareyipyip/set-version-action@v2
         with:

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The package can be installed by adding `charon` to your list of dependencies in 
 ```elixir
 def deps do
   [
-    {:charon, "~> 0.0.0+development"},
+    {:charon, "~> 2.0"},
     # to use the default Charon.TokenFactory.Jwt
     {:jason, "~> 1.0"}
   ]


### PR DESCRIPTION
While the version is correctly injected in the readme, we get a too-specific version on hexdocs ("~> 2.5.0") and the injection doesn't work for the readme on github that people actually use (that of the main branch). So let's just fix the major version and bump it when we release a new major version.