### PR TITLE
Sign RedisStore sessions, add Utils.Crypto, use LocalStore in most tests

### DIFF
--- a/lib/charon/internal.ex
+++ b/lib/charon/internal.ex
@@ -40,9 +40,8 @@ defmodule Charon.Internal do
   @doc """
   Generate a random URL-encoded string of `byte_size` bits.
   """
-  def random_url_encoded(byte_size) do
-    byte_size |> :crypto.strong_rand_bytes() |> url_encode()
-  end
+  @deprecated "Use `Charon.Utils.Crypto.random_url_encoded/1`"
+  def random_url_encoded(byte_size), do: Charon.Utils.Crypto.random_url_encoded(byte_size)
 
   @doc """
   Determine if the token's signature transport mechanism is `:cookie` or `:bearer`.

--- a/lib/charon/session_plugs.ex
+++ b/lib/charon/session_plugs.ex
@@ -6,6 +6,7 @@ defmodule Charon.SessionPlugs do
   alias Plug.Conn
   require Logger
   alias Charon.{Config, Internal, TokenFactory, SessionStore}
+  alias Charon.Utils.Crypto
   use Internal.Constants
   alias Charon.Models.{Session, Tokens}
 
@@ -142,7 +143,7 @@ defmodule Charon.SessionPlugs do
     session_type = opts[:session_type] || :full
 
     # the refresh token id is renewed every time so that refresh tokens can be single-use only
-    refresh_token_id = Internal.random_url_encoded(16)
+    refresh_token_id = Crypto.random_url_encoded(16)
 
     # update the existing session or create a new one
     session =
@@ -162,7 +163,7 @@ defmodule Charon.SessionPlugs do
           created_at: now,
           expires_at: if(session_ttl == :infinite, do: :infinite, else: session_ttl + now),
           extra_payload: extra_session_payload,
-          id: Internal.random_url_encoded(16),
+          id: Crypto.random_url_encoded(16),
           prev_tokens_fresh_from: now,
           refresh_expires_at: now + max_refresh_ttl,
           refresh_token_id: refresh_token_id,
@@ -193,7 +194,7 @@ defmodule Charon.SessionPlugs do
     a_payload =
       shared_payload
       |> Map.merge(%{
-        "jti" => Internal.random_url_encoded(16),
+        "jti" => Crypto.random_url_encoded(16),
         "exp" => access_exp,
         "type" => "access"
       })

--- a/lib/charon/session_store/redis_store/config.ex
+++ b/lib/charon/session_store/redis_store/config.ex
@@ -4,9 +4,19 @@ defmodule Charon.SessionStore.RedisStore.Config do
   """
   alias Charon.SessionStore.RedisStore
   @enforce_keys [:redix_module]
-  defstruct [:redix_module, key_prefix: "charon_"]
+  defstruct [
+    :redix_module,
+    key_prefix: "charon_",
+    get_signing_key: &RedisStore.default_signing_key/1,
+    allow_unsigned?: true
+  ]
 
-  @type t :: %__MODULE__{redix_module: module(), key_prefix: String.t()}
+  @type t :: %__MODULE__{
+          redix_module: module(),
+          key_prefix: String.t(),
+          get_signing_key: (Charon.Config.t() -> binary()),
+          allow_unsigned?: boolean()
+        }
 
   @doc """
   Build config struct from enumerable (useful for passing in application environment).

--- a/lib/charon/token_plugs.ex
+++ b/lib/charon/token_plugs.ex
@@ -371,7 +371,7 @@ defmodule Charon.TokenPlugs do
 
   ## Doctests
 
-      iex> command(["SET", session_key("a", 1), test_session() |> :erlang.term_to_binary()])
+      iex> SessionStore.upsert(test_session(refresh_expires_at: 999999999999999), @config)
       iex> conn = conn() |> set_token_payload(%{"sid" => "a", "sub" => 1, "styp" => "full"})
       iex> %Session{} = conn |> load_session(@config) |> Internal.get_private(@session)
 

--- a/lib/charon/utils/crypto.ex
+++ b/lib/charon/utils/crypto.ex
@@ -1,0 +1,61 @@
+defmodule Charon.Utils.Crypto do
+  @moduledoc """
+  Encrypt/decrypt, sign/verify, secure compare binaries etc.
+  """
+  import Charon.Internal
+
+  @encr_alg :chacha20
+  @hmac_alg :sha256
+  @iv_size 16
+
+  @doc """
+  Encrypt the plaintext into a binary using the provided key.
+  """
+  @spec encrypt(binary, binary) :: binary
+  def encrypt(plaintext, key) do
+    iv = :crypto.strong_rand_bytes(@iv_size)
+    # prefix a zero byte to detect decryption failure
+    # because it is only one byte there is a chance of failed decryption not being detected
+    # this is acceptable because it will fail really often and be quite clear from all the crashes
+    prefixed_plaintext = [0 | plaintext]
+    encrypted = :crypto.crypto_one_time(@encr_alg, key, iv, prefixed_plaintext, true)
+    <<iv::binary, encrypted::binary>>
+  end
+
+  @doc """
+  Decrypt a binary using the provided key and return the plaintext or an error.
+  """
+  @spec decrypt(binary, binary) :: {:ok, binary} | {:error, :decryption_failed}
+  def decrypt(_encrypted = <<iv::binary-size(@iv_size), ciphertext::binary>>, key) do
+    case :crypto.crypto_one_time(@encr_alg, key, iv, ciphertext, false) do
+      _prefixed_plaintext = <<0, plaintext::binary>> -> {:ok, plaintext}
+      _ -> {:error, :decryption_failed}
+    end
+  end
+
+  @doc """
+  Constant time memory comparison for fixed length binaries, such as results of HMAC computations.
+
+  Returns true if the binaries are identical, false if they are of the same length but not identical. The function raises an error:badarg exception if the binaries are of different size.
+  """
+  @spec constant_time_compare(binary, binary) :: boolean()
+  if function_exported?(:crypto, :hash_equals, 2) do
+    def constant_time_compare(bin_a, bin_b), do: :crypto.hash_equals(bin_a, bin_b)
+  else
+    def constant_time_compare(bin_a, bin_b), do: Plug.Crypto.secure_compare(bin_a, bin_b)
+  end
+
+  @doc """
+  Generate a random URL-encoded string of `byte_size` bytes.
+  """
+  @spec random_url_encoded(pos_integer()) :: binary
+  def random_url_encoded(byte_size) do
+    byte_size |> :crypto.strong_rand_bytes() |> url_encode()
+  end
+
+  @doc """
+  Calculate a HMAC of data using key. The algorithm is #{@hmac_alg}.
+  """
+  @spec hmac(iodata, binary) :: binary
+  def hmac(data, key), do: :crypto.mac(:hmac, @hmac_alg, key, data)
+end

--- a/test/charon/session_integration_test.exs
+++ b/test/charon/session_integration_test.exs
@@ -1,7 +1,7 @@
 defmodule Charon.SessionIntegrationTest do
   use ExUnit.Case, async: false
   use Charon.Internal.Constants
-  alias Charon.{TestRedix, TestPipeline, SessionPlugs, Utils, Internal, TestUtils}
+  alias Charon.{TestPipeline, SessionPlugs, Utils, Internal, TestUtils}
   import TestUtils
   import Plug.Conn
   import Internal
@@ -10,13 +10,8 @@ defmodule Charon.SessionIntegrationTest do
   @moduletag :capture_log
   @config Charon.TestConfig.get()
 
-  setup_all do
-    TestRedix.init()
-    :ok
-  end
-
   setup do
-    TestRedix.before_each()
+    start_supervised!(Charon.SessionStore.LocalStore)
     :ok
   end
 

--- a/test/charon/token_plugs_unit_test.exs
+++ b/test/charon/token_plugs_unit_test.exs
@@ -1,14 +1,11 @@
 defmodule Charon.TokenPlugsTest do
   use ExUnit.Case
   use Charon.Internal.Constants
-  alias Charon.{Utils, Internal}
-  alias Charon.TestRedix
-  alias Charon.TokenPlugs
+  alias Charon.{Utils, Internal, TokenPlugs, SessionStore}
   import Charon.TestUtils
   import Utils
   import Plug.Conn
   import Plug.Test
-  import TestRedix, only: [command: 1]
   import TokenPlugs
   alias TokenPlugs.PutAssigns
   alias Charon.Models.Session
@@ -25,13 +22,8 @@ defmodule Charon.TokenPlugsTest do
     end
   end
 
-  setup_all do
-    TestRedix.init()
-    :ok
-  end
-
   setup do
-    TestRedix.before_each()
+    start_supervised!(Charon.SessionStore.LocalStore)
     :ok
   end
 

--- a/test/charon/utils/crypto_test.exs
+++ b/test/charon/utils/crypto_test.exs
@@ -1,0 +1,22 @@
+defmodule Charon.Utils.CryptoTest do
+  use ExUnit.Case, async: true
+  import Charon.Utils.Crypto
+
+  @key <<43, 174, 120, 110, 62, 41, 62, 164, 202, 99, 83, 37, 249, 220, 141, 107, 100, 134, 117,
+         106, 218, 69, 234, 61, 172, 57, 117, 185, 145, 40, 25, 255>>
+  @wrong_key <<232, 111, 192, 185, 177, 205, 141, 32, 158, 126, 100, 146, 16, 49, 97, 144, 236,
+               38, 216, 67, 37, 243, 34, 65, 76, 210, 90, 29, 95, 179, 169, 211>>
+
+  describe "encryption" do
+    test "works" do
+      assert {:ok, "hello world"} = "hello world" |> encrypt(@key) |> decrypt(@key)
+    end
+
+    test "fails graciously" do
+      assert {:error, :decryption_failed} =
+               <<159, 70, 130, 39, 86, 28, 250, 2, 68, 155, 255, 136, 37, 108, 191, 229, 119, 115,
+                 50, 159, 53, 42, 107, 147, 176, 82, 33, 38>>
+               |> decrypt(@wrong_key)
+    end
+  end
+end

--- a/test/support/test_config.ex
+++ b/test/support/test_config.ex
@@ -4,9 +4,7 @@ defmodule Charon.TestConfig do
   @config Charon.Config.from_enum(
             token_issuer: "my_test_app",
             get_base_secret: &__MODULE__.secret/0,
-            optional_modules: %{
-              Charon.SessionStore.RedisStore => %{redix_module: Charon.TestRedix}
-            }
+            session_store_module: Charon.SessionStore.LocalStore
           )
 
   def get(), do: @config


### PR DESCRIPTION
See #40 for rationale.

`Utils.Crypto` centralizes the framework's crypto functionality, meaning `CharonOauth2.Utils.Crypto` can be dropped.

Using `SessionStore.LocalStore` in most tests makes sense, since this store behaves the same as RedisStore but makes tests a little more decoupled from one another.