### PR TITLE
Add `RedisStore.migrate_sessions/1`

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,4 +1,4 @@
-alias Charon.{Internal, SessionPlugs, TokenPlugs, Utils}
+alias Charon.{Internal, SessionPlugs, TokenPlugs, Utils, SessionStore}
 alias Charon.Models.{Session, Tokens}
 alias Charon.TokenFactory.Jwt
 alias Charon.SessionStore.RedisStore

--- a/test/charon/session_store/redis_store_test.exs
+++ b/test/charon/session_store/redis_store_test.exs
@@ -381,4 +381,23 @@ defmodule Charon.SessionStore.RedisStoreTest do
              ] == Enum.sort(keys)
     end
   end
+
+  describe "migrate_sessions/1" do
+    test "signs sessions and reinserts with new key" do
+      session_key = RedisStore.old_session_key(@sid, to_string(@uid), "full", "charon_")
+
+      command(["ZADD", user_sessions_key(@uid), @exp, session_key])
+      command(["SET", session_key, @serialized])
+
+      assert capture_log(fn ->
+               RedisStore.migrate_sessions(@config)
+             end) =~ "Unsigned session"
+
+      assert {:ok, keys} = command(~w(KEYS *))
+      assert [session_key = "charon_.s.426.full.a", "charon_.u.426"] == Enum.sort(keys)
+
+      assert {:ok, <<"signed.", _mac::256, ".", _session::binary>>} =
+               command(["GET", session_key])
+    end
+  end
 end


### PR DESCRIPTION
To use the glorious new redis keys and signed sessions of #41 and #42