### PR TITLE
Move Crypto module to Internal, drop from public API (breaking)

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,7 +1,8 @@
-alias Charon.{Internal, SessionPlugs, TokenPlugs, Utils, SessionStore}
-alias Charon.Models.{Session, Tokens}
-alias Charon.TokenFactory.Jwt
-alias Charon.SessionStore.RedisStore
+alias Charon.{Internal, SessionPlugs, TokenPlugs, Utils, SessionStore, TokenFactory, Models}
 alias Charon.Config, as: CharonConfig
+alias Models.{Session, Tokens}
+alias TokenFactory.Jwt
+alias SessionStore.{RedisStore, LocalStore, DummyStore}
+alias Internal.{Crypto}
 
 charon_config = CharonConfig.from_enum(token_issuer: "local", get_base_secret: fn -> "very secure string" end)

--- a/README.md
+++ b/README.md
@@ -266,4 +266,4 @@ And that's it :) Optionally, you can add get-all, logout-all and logout-other se
 
 Copyright (c) 2023, YipYip B.V.
 
-Charon source code is licensed under the [Apache-2.0 License](LICENSE.md)
+Charon source code is licensed under the [Apache-2.0 License](./LICENSE.md)

--- a/lib/charon/internal.ex
+++ b/lib/charon/internal.ex
@@ -41,7 +41,7 @@ defmodule Charon.Internal do
   Generate a random URL-encoded string of `byte_size` bits.
   """
   @deprecated "Use `Charon.Utils.Crypto.random_url_encoded/1`"
-  def random_url_encoded(byte_size), do: Charon.Utils.Crypto.random_url_encoded(byte_size)
+  def random_url_encoded(byte_size), do: Charon.Internal.Crypto.random_url_encoded(byte_size)
 
   @doc """
   Determine if the token's signature transport mechanism is `:cookie` or `:bearer`.

--- a/lib/charon/internal/crypto.ex
+++ b/lib/charon/internal/crypto.ex
@@ -1,7 +1,5 @@
-defmodule Charon.Utils.Crypto do
-  @moduledoc """
-  Encrypt/decrypt, sign/verify, secure compare binaries etc.
-  """
+defmodule Charon.Internal.Crypto do
+  @moduledoc false
   import Charon.Internal
 
   # this ensures function_exported/3 works for this module
@@ -37,10 +35,8 @@ defmodule Charon.Utils.Crypto do
   end
 
   @doc """
-  Constant time memory comparison for fixed length binaries, such as results of HMAC computations.
-
-  Returns true if the binaries are identical, false if they are of the same length but not identical.
-  The function raises an `ArgumentError` if the binaries are of different size.
+  Constant time memory comparison of fixed length binaries, such as results of HMAC computations.
+  Binaries of different lengths always return `false`.
 
   ## Doctests
 
@@ -48,9 +44,12 @@ defmodule Charon.Utils.Crypto do
       true
       iex> constant_time_compare(<<0>>, <<1>>)
       false
+      iex> constant_time_compare(<<1>>, <<1, 2>>)
+      false
   """
   @spec constant_time_compare(binary, binary) :: boolean()
   if function_exported?(:crypto, :hash_equals, 2) do
+    def constant_time_compare(bin_a, bin_b) when bit_size(bin_a) != bit_size(bin_b), do: false
     def constant_time_compare(bin_a, bin_b), do: :crypto.hash_equals(bin_a, bin_b)
   else
     def constant_time_compare(bin_a, bin_b), do: Plug.Crypto.secure_compare(bin_a, bin_b)

--- a/lib/charon/session_plugs.ex
+++ b/lib/charon/session_plugs.ex
@@ -5,10 +5,10 @@ defmodule Charon.SessionPlugs do
   """
   alias Plug.Conn
   require Logger
-  alias Charon.{Config, Internal, TokenFactory, SessionStore}
-  alias Charon.Utils.Crypto
+  alias Charon.{Config, Internal, TokenFactory, SessionStore, Models}
   use Internal.Constants
-  alias Charon.Models.{Session, Tokens}
+  alias Internal.Crypto
+  alias Models.{Session, Tokens}
 
   @type upsert_session_opts :: [
           access_claim_overrides: %{required(String.t()) => any()},

--- a/lib/charon/session_store/behaviour.ex
+++ b/lib/charon/session_store/behaviour.ex
@@ -14,8 +14,7 @@ defmodule Charon.SessionStore.Behaviour do
   but may define additional functions and instructions to take care of such things
   (like a `cleanup/0` that should run periodically).
   """
-  alias Charon.Session
-  alias Charon.Config
+  alias Charon.{Session, Config}
 
   @optional_callbacks [get_all: 3, delete_all: 3]
 

--- a/lib/charon/session_store/redis_store.ex
+++ b/lib/charon/session_store/redis_store.ex
@@ -34,10 +34,10 @@ defmodule Charon.SessionStore.RedisStore do
   This module depends on a correctly configured `Redix` module with `command/1` and `pipeline/1` functions. See https://hexdocs.pm/redix for instructions.
   """
   @behaviour Charon.SessionStore.Behaviour
-  alias Charon.Config
-  alias Charon.Internal
+  alias Charon.{Config, Internal, Utils}
   import Charon.SessionStore.RedisStore.Config, only: [get_mod_config: 1]
-  import Charon.Utils.{KeyGenerator, Crypto}
+  import Utils.{KeyGenerator}
+  import Internal.Crypto
   require Logger
 
   @multi ~W(MULTI)

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule Charon.MixProject do
       name: "Charon",
       docs: [
         source_ref: "main",
-        extras: ["./README.md"],
+        extras: ~w(./README.md ./LICENSE.md),
         main: "readme"
       ]
     ]

--- a/test/charon/config_test.exs
+++ b/test/charon/config_test.exs
@@ -28,7 +28,9 @@ defmodule Charon.ConfigTest do
     },
     RedisStore.Config => %{
       redix_module: :required,
-      key_prefix: "charon_"
+      key_prefix: "charon_",
+      get_signing_key: &RedisStore.default_signing_key/1,
+      allow_unsigned?: true
     }
   }
 

--- a/test/charon/internal/crypto_test.exs
+++ b/test/charon/internal/crypto_test.exs
@@ -1,6 +1,6 @@
-defmodule Charon.Utils.CryptoTest do
+defmodule Charon.Internal.CryptoTest do
   use ExUnit.Case, async: true
-  alias Charon.Utils.Crypto
+  alias Charon.Internal.Crypto
   import Crypto
 
   @key <<43, 174, 120, 110, 62, 41, 62, 164, 202, 99, 83, 37, 249, 220, 141, 107, 100, 134, 117,
@@ -18,16 +18,6 @@ defmodule Charon.Utils.CryptoTest do
                <<159, 70, 130, 39, 86, 28, 250, 2, 68, 155, 255, 136, 37, 108, 191, 229, 119, 115,
                  50, 159, 53, 42, 107, 147, 176, 82, 33, 38>>
                |> decrypt(@wrong_key)
-    end
-  end
-
-  describe "constant_time_compare/2" do
-    if function_exported?(:crypto, :hash_equals, 2) do
-      test "raises ArgumentError on different size binaries" do
-        assert_raise ArgumentError, fn ->
-          constant_time_compare(<<0>>, <<1, 2>>)
-        end
-      end
     end
   end
 

--- a/test/charon/session_store/redis_store_test.exs
+++ b/test/charon/session_store/redis_store_test.exs
@@ -3,7 +3,7 @@ defmodule Charon.SessionStore.RedisStoreTest do
   import ExUnit.CaptureLog
   alias Charon.SessionStore.RedisStore
   import Charon.{TestUtils, Internal, TestHelpers}
-  import Charon.Utils.Crypto
+  import Charon.Internal.Crypto
   alias Charon.{TestRedix, TestConfig}
   import TestRedix, only: [command: 1]
 


### PR DESCRIPTION
This is technically a breaking change, but the Crypto module has only been added yesterday and was never meant to be part of the package's public API. It is unlikely that there is dependent code at this point.