### PR TITLE
Opt-locking session stores and single-round-trip-only RedisStore implementation

### DIFF
--- a/.github/workflows/cd_workflow.yml
+++ b/.github/workflows/cd_workflow.yml
@@ -28,6 +28,11 @@ jobs:
         with:
           source: tag
           file_path: mix.exs
+      - name: Set version in lua_functions.ex
+        uses: weareyipyip/set-version-action@v2
+        with:
+          source: tag
+          file_path: lib/charon/session_store/redis_store/lua_functions.ex
 
       - uses: erlef/setup-beam@v1
         with:

--- a/.iex.exs
+++ b/.iex.exs
@@ -5,5 +5,5 @@ alias TokenFactory.Jwt
 alias SessionStore.{RedisStore, LocalStore, DummyStore}
 alias Internal.{Crypto}
 
-RedisStore.ConnectionPool.start_link
+RedisStore.start_link()
 charon_config = CharonConfig.from_enum(token_issuer: "local", get_base_secret: fn -> "very secure string" end)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,21 @@
 
 ### Breaking
 
-- `Charon.SessionStore.RedisStore` now requires Redis >= 7.x.x
+- `Charon.SessionStore.RedisStore`
+
+  - requires Redis >= 7.x.x
+  - uses a Redix connection pool by itself, which requires initialization under the application supervision tree
+  - implements optimistic locking
+  - uses a new storage format based on hash sets, to which sessions are migrated starting from Charon 2.8
+  - uses Redis functions to implement all session store operations in a single round trip to the Redis instance
+  - support for unsigned binaries has been dropped
+    - config options `:allow_unsigned?` has been removed
+    - `migrate_sessions/1` has been removed
+    - sessions that have not been migrated using `migrate_sessions/1` can no longer be used
+
+- `Charon.SessionStore.LocalStore`
+
+  - implements optimistic locking
 
 - 2.x marked-deprecated functions have been removed:
 
@@ -16,15 +30,6 @@
   - `Charon.SessionStore.get_all/2`
   - `Charon.SessionStore.RedisStore.cleanup/1`
   - `Charon.TokenPlugs.verify_refresh_token_fresh/2`
-
-- `Charon.SessionStore.RedisStore` support for unsigned binaries has been dropped.
-
-  - config options `:allow_unsigned?` has been removed
-  - `migrate_sessions/1` has been removed
-  - sessions that have not been migrated using `migrate_sessions/1` can no longer be used
-
-- `Charon.SessionStore.RedisStore` now uses a Redix connection pool by itself,
-  which requires initialization under the application supervision tree.
 
 - `Charon.TokenPlugs.verify_token_signature/2` no longer adds default value "full" for claim "styp".
   This should not result in issues for tokens created by Charon 2.x.x deployments.

--- a/README.md
+++ b/README.md
@@ -66,13 +66,9 @@ Configuration has been made easy using a config helper struct `Charon.Config`, w
 
 ```elixir
 # Charon itself only requires a token issuer and a base secret getter.
-# The default implementation of session store requires some config as well.
 @my_config Charon.Config.from_enum(
              token_issuer: "MyApp",
              get_base_secret: &MyApp.get_base_secret/0
-             optional_modules: %{
-               Charon.SessionStore.RedisStore => %{redix_module: MyApp.Redix}
-             }
            )
 
 # it is possible to use the application environment as well if you wish

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Configuration has been made easy using a config helper struct `Charon.Config`, w
 
 A session store can be created using multiple state stores, be it a database or a GenServer. All you have to do is implement a simple behaviour which you can find in `Charon.SessionStore.Behaviour`. Two default implementations are provided, `Charon.SessionStore.RedisStore` uses a Redis database, `Charon.SessionStore.LocalStore` uses a GenServer. Use `Charon.SessionStore.DummyStore` in case you don't want to use server-side sessions and prefer fully stateless tokens. The default and recommended option is RedisStore. Use LocalStore for local testing only - it is NOT persistent.
 
-In order to use RedisStore, add `Charon.SessionStore.RedisStore.ConnectionPool` to your supervision tree:
+In order to use RedisStore, add `Charon.SessionStore.RedisStore` to your supervision tree:
 
 ```elixir
 # application.ex
@@ -93,7 +93,7 @@ def start(_, ) do
 
   children = [
     ...
-    {Charon.SessionStore.RedisStore.ConnectionPool, size: 15, redix_opts: redix_opts},
+    {Charon.SessionStore.RedisStore, pool_size: 15, redix_opts: redix_opts},
     ...
   ]
 

--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -6,7 +6,8 @@
 
 If you use `Charon.SessionStore.RedisStore` you must do the following before upgrading to 3.x:
 
-1.  Upgrade your Redis instance to 7.x.x
+1.  Update Charon to >= 2.8.0
+1.  Upgrade your Redis instance to 7.x.x (this can be an in-place upgrade)
 1.  Run `Charon.SessionStore.RedisStore.migrate_sessions/1`
 1.  If you explicitly set config options `:allow_unsigned?` and `:redix_module`, you must remove your overrides. Support for these config options has been dropped.
 1.  Initialize the Redix connection pool in your supervision tree. See readme section [setting up a sessionstore](./README.md#setting-up-a-session-store).

--- a/lib/charon/models/session.ex
+++ b/lib/charon/models/session.ex
@@ -2,7 +2,7 @@ defmodule Charon.Models.Session do
   @moduledoc """
   A session.
   """
-  @latest_version 6
+  @latest_version 7
 
   @enforce_keys [
     :created_at,
@@ -24,6 +24,7 @@ defmodule Charon.Models.Session do
     :tokens_fresh_from,
     :user_id,
     extra_payload: %{},
+    lock_version: 0,
     prev_tokens_fresh_from: 0,
     type: :full,
     version: @latest_version
@@ -34,6 +35,7 @@ defmodule Charon.Models.Session do
           expires_at: integer | :infinite,
           extra_payload: map(),
           id: String.t(),
+          lock_version: integer(),
           prev_tokens_fresh_from: integer,
           refresh_expires_at: integer,
           refresh_token_id: binary(),
@@ -123,6 +125,11 @@ defmodule Charon.Models.Session do
   ###########
 
   defp update(session = %{version: @latest_version}, _), do: session
+
+  # v6: no lock_version yet
+  defp update(session = %{version: 6}, config) do
+    session |> Map.merge(%{version: 7, lock_version: 0}) |> update(config)
+  end
 
   # v5: tokens_fresh_from was still called t_gen_fresh_at, which is less descriptive
   defp update(session = %{version: 5, prev_t_gen_fresh_at: p, t_gen_fresh_at: c}, config) do

--- a/lib/charon/session_plugs/session_storage_error.ex
+++ b/lib/charon/session_plugs/session_storage_error.ex
@@ -1,0 +1,8 @@
+defmodule Charon.SessionPlugs.SessionStorageError do
+  @moduledoc """
+  Error raised when a new/updated session could not be stored.
+  """
+  defexception message:
+                 "An error occurred when storing a new/updated session. The operation was cancelled.",
+               plug_status: 500
+end

--- a/lib/charon/session_plugs/update_conflict_error.ex
+++ b/lib/charon/session_plugs/update_conflict_error.ex
@@ -1,0 +1,7 @@
+defmodule Charon.SessionPlugs.SessionUpdateConflictError do
+  @moduledoc """
+  Error raised on an optimistic locking error when updating an existing session.
+  """
+  defexception message: "A conflict occurred when updating a session. The update was cancelled.",
+               plug_status: 409
+end

--- a/lib/charon/session_store/redis_store.ex
+++ b/lib/charon/session_store/redis_store.ex
@@ -1,12 +1,23 @@
 if Code.ensure_loaded?(Redix) and Code.ensure_loaded?(:poolboy) do
   defmodule Charon.SessionStore.RedisStore do
+    @supervisor_opts_docs """
+      - `:name` (default module name) name of the supervisor
+      - `:pool_size` (default 10) total number of (local) normal workers
+      - `:pool_max_overflow` (default 5) max number of (local) extra workers in case of high load
+      - `:redix_opts` passed to `Redix.start_link/1`
+
+    The pool and its config options are local to the Elixir/OTP node,
+    so if you use multiple nodes, the total connection count to Redis maxes out at
+    `(pool_size + pool_max_overflow) * number_of_nodes`.
+    """
+
     @moduledoc """
     A persistent session store based on Redis, which implements behaviour `Charon.SessionStore`.
     In addition to the required callbacks, this store also provides `get_all/3` and `delete_all/3` (for a user) functions.
 
     ## Redis requirements
 
-    This module needs a Redis >= 7.0.0 instance.
+    This module needs a Redis >= 7.0.0 instance and needs permissions to create Redis functions.
 
     ## Config
 
@@ -17,8 +28,7 @@ if Code.ensure_loaded?(Redix) and Code.ensure_loaded?(:poolboy) do
           optional_modules: %{
             Charon.SessionStore.RedisStore => %{
               key_prefix: "charon_",
-              get_signing_key: &RedisStore.default_signing_key/1,
-              debug_log?: false
+              get_signing_key: &RedisStore.default_signing_key/1
             }
           }
         )
@@ -26,172 +36,84 @@ if Code.ensure_loaded?(Redix) and Code.ensure_loaded?(:poolboy) do
     The following options are supported:
       - `:key_prefix` (optional). A string prefix for the Redis keys that are sessions.
       - `:get_signing_key` (optional). A getter/1 that returns the key that is used to sign and verify serialized session binaries.
-      - `:debug_log?` (optional). Enable debug logging of raw Redis commands.
 
-    ## Initialize connection pool
+    ## Initialize store
 
-    RedisStore uses a connection pool, which you need to add to your application's supervision tree.
-    See `Charon.SessionStore.RedisStore.ConnectionPool`.
+    RedisStore uses a connection pool and has to register Redis functions on startup.
+    In order to initialize it, you must add RedisStore to your application's supervision tree.
+
+        # in application.ex
+        def start(_, ) do
+          redix_opts = [host: "localhost", port: 6379, password: "supersecret", database: 0]
+
+          children = [
+            ...
+            {Charon.SessionStore.RedisStore, pool_size: 15, redix_opts: redix_opts},
+            ...
+          ]
+
+          opts = [strategy: :one_for_one, name: MyApp.Supervisor]
+          Supervisor.start_link(children, opts)
+        end
+
+    ### Options
+    #{@supervisor_opts_docs}
     """
-    @behaviour Charon.SessionStore.Behaviour
-    alias Charon.{Config, Internal, Utils}
-    alias __MODULE__.{RedisClient, ConnectionPool}
-    import Charon.SessionStore.RedisStore.Config, only: [get_mod_config: 1]
+    use Supervisor
+    alias Charon.SessionStore.Behaviour, as: SessionStoreBehaviour
+    @behaviour SessionStoreBehaviour
+    alias Charon.{Config, Utils}
+    alias __MODULE__.{LuaFunctions, ConnectionPool, StoreImpl}
     import Utils.{KeyGenerator}
-    import Internal.Crypto
     require Logger
 
-    @multi ~W(MULTI)
-    @exec ~W(EXEC)
-    @unwatch ~w(UNWATCH)
+    @doc """
+    Start the RedisStore supervisor, which registeres all required Redis functions and initiates the connection pool.
 
-    @impl true
-    def get(session_id, user_id, type, config) do
-      mod_conf = get_mod_config(config)
-      {user_id_str, type_str, key_prefix} = key_data(user_id, type, mod_conf)
-      session_key = session_key(session_id, user_id_str, type_str, key_prefix)
+    ## Options
+    #{@supervisor_opts_docs}
+    """
+    @spec start_link(keyword) :: :ignore | {:error, any} | {:ok, pid}
+    def start_link(opts \\ []) do
+      name = opts[:name] || __MODULE__
+      size = opts[:pool_size] || 10
+      max_overflow = opts[:pool_max_overflow] || 5
+      redix_opts = opts[:redix_opts] || []
 
-      ["GET", session_key]
-      |> RedisClient.command(mod_conf.debug_log?)
-      |> case do
-        {:ok, serialized_or_nil} -> deserialize(serialized_or_nil, mod_conf, config)
-        error -> error
-      end
+      :ok = LuaFunctions.register_functions(redix_opts)
+
+      init_arg = [
+        pool_opts: [
+          size: size,
+          max_overflow: max_overflow,
+          redix_opts: redix_opts,
+          name: String.to_atom("#{name}.Pool")
+        ]
+      ]
+
+      Supervisor.start_link(__MODULE__, init_arg, name: name)
     end
 
-    @impl true
-    def upsert(
-          session = %{
-            id: sid,
-            user_id: uid,
-            type: type,
-            refreshed_at: now,
-            expires_at: s_exp,
-            refresh_expires_at: exp,
-            lock_version: lock_version
-          },
-          config
-        ) do
-      ConnectionPool.transaction(fn redix_conn ->
-        mod_conf = get_mod_config(config)
-        {uid_str, type_str, key_prefix} = key_data(uid, type, mod_conf)
-        session_key = session_key(sid, uid_str, type_str, key_prefix)
-        set_key = set_key(uid_str, type_str, key_prefix)
-
-        with {:ok, [_, serialized_or_nil]} <-
-               [["WATCH", session_key, set_key], ["GET", session_key]]
-               |> RedisClient.conn_pipeline(redix_conn, mod_conf.debug_log?),
-             deserialized = deserialize(serialized_or_nil, mod_conf, config),
-             lock_ok? = is_nil(deserialized) or deserialized.lock_version == lock_version,
-             nil <- unless(lock_ok?, do: {:error, :conflict}) do
-          exp_str = Integer.to_string(exp)
-          now = Integer.to_string(now)
-          serialized = %{session | lock_version: lock_version + 1} |> serialize(mod_conf, config)
-
-          # upsert the actual session as a separate key-value pair that expires when the refresh token expires
-          upsert_session_c = ["SET", session_key, serialized, "EXAT", exp_str]
-          # add session key to user's session set, with exp timestamp as score (or update score)
-          upsert_set_c = ["ZADD", set_key, exp_str, session_key]
-          get_set_exp_c = get_s_exp_cmd(set_key)
-          prune_set_c = prune_session_set_cmd(set_key, now)
-
-          if s_exp == exp do
-            # s_exp == exp, we can't assume that this session has the highest refresh exp
-            # because this session's refresh_expires_at is reduced so that it is <= expires_at
-
-            [@multi, get_set_exp_c, upsert_session_c, upsert_set_c, prune_set_c, @exec]
-            |> RedisClient.conn_pipeline(redix_conn, mod_conf.debug_log?)
-            |> case do
-              {:ok, [_, _, _, _, _, nil]} ->
-                {:error, :conflict}
-
-              {:ok, [_, _, _, _, _, [set_exp, _, _, _]]} when is_integer(set_exp) ->
-                if exp > set_exp, do: put_s_exp(set_key, exp_str, mod_conf)
-                :ok
-
-              error ->
-                redis_result_to_error(error)
-            end
-          else
-            # s_exp != exp; we can assume that this session has the highest refresh exp of all of the user's sessions
-            set_exp_c = put_s_exp_cmd(set_key, exp_str)
-
-            [@multi, upsert_session_c, upsert_set_c, set_exp_c, prune_set_c, @exec]
-            |> RedisClient.conn_pipeline(redix_conn, mod_conf.debug_log?)
-            |> case do
-              {:ok, [_, _, _, _, _, nil]} -> {:error, :conflict}
-              {:ok, [_, _, _, _, _, [_, _, _, _]]} -> :ok
-              error -> redis_result_to_error(error)
-            end
-          end
-        else
-          error ->
-            RedisClient.conn_command(@unwatch, redix_conn, mod_conf.debug_log?)
-            error
-        end
-      end)
+    @doc false
+    @impl Supervisor
+    def init(opts) do
+      [{ConnectionPool, opts[:pool_opts]}] |> Supervisor.init(strategy: :one_for_one)
     end
 
-    @impl true
-    def delete(session_id, user_id, type, config) do
-      mod_conf = get_mod_config(config)
-      {user_id_str, type_str, key_prefix} = key_data(user_id, type, mod_conf)
-      session_key = session_key(session_id, user_id_str, type_str, key_prefix)
-      set_key = set_key(user_id_str, type_str, key_prefix)
-      now = Internal.now() |> Integer.to_string()
+    @impl SessionStoreBehaviour
+    defdelegate get(session_id, user_id, type, config), to: StoreImpl
 
-      delete_c = ["DEL", session_key]
-      delete_key_c = ["ZREM", set_key, session_key]
-      max_exp_c = get_max_exp_session_cmd(set_key)
-      get_set_exp_c = get_s_exp_cmd(set_key)
-      prune_set_c = prune_session_set_cmd(set_key, now)
+    @impl SessionStoreBehaviour
+    defdelegate upsert(session, config), to: StoreImpl
 
-      [@multi, get_set_exp_c, delete_c, delete_key_c, prune_set_c, max_exp_c, @exec]
-      |> RedisClient.pipeline(mod_conf.debug_log?)
-      |> case do
-        {:ok, [_, _, _, _, _, _, [set_exp, _, _, _, map_exp_session]]} when is_integer(set_exp) ->
-          # EXPIRETIME returns -2 if key does not exist
-          set_existed? = set_exp > -2
-          set_exp_str = set_exp |> to_string()
-          {set_exists?, max_session_exp_str} = parse_zrange_withscores(map_exp_session)
+    @impl SessionStoreBehaviour
+    defdelegate delete(session_id, user_id, type, config), to: StoreImpl
 
-          update_set_exp? = set_existed? and set_exists? and set_exp_str != max_session_exp_str
-          if update_set_exp?, do: put_s_exp(set_key, max_session_exp_str, mod_conf)
-          :ok
+    @impl SessionStoreBehaviour
+    defdelegate get_all(user_id, type, config), to: StoreImpl
 
-        error ->
-          redis_result_to_error(error)
-      end
-    end
-
-    @impl true
-    def get_all(user_id, type, config) do
-      mod_conf = get_mod_config(config)
-      {user_id_str, type_str, key_prefix} = key_data(user_id, type, mod_conf)
-
-      with {:ok, keys = [_ | _]} <-
-             get_valid_session_keys(user_id_str, type_str, key_prefix, mod_conf),
-           {:ok, values} <- RedisClient.command(["MGET" | keys], mod_conf.debug_log?) do
-        values |> Stream.map(&deserialize(&1, mod_conf, config)) |> Enum.reject(&is_nil/1)
-      else
-        {:ok, []} -> []
-        other -> other
-      end
-    end
-
-    @impl true
-    def delete_all(user_id, type, config) do
-      mod_conf = get_mod_config(config)
-      {user_id_str, type_str, key_prefix} = key_data(user_id, type, mod_conf)
-
-      with {:ok, keys} <- get_session_keys(user_id_str, type_str, key_prefix, mod_conf),
-           to_delete = [set_key(user_id_str, type_str, key_prefix) | keys],
-           {:ok, _} <- ["DEL" | to_delete] |> RedisClient.command(mod_conf.debug_log?) do
-        :ok
-      else
-        error -> redis_result_to_error(error)
-      end
-    end
+    @impl SessionStoreBehaviour
+    defdelegate delete_all(user_id, type, config), to: StoreImpl
 
     @doc false
     def init_config(enum), do: __MODULE__.Config.from_enum(enum)
@@ -201,113 +123,19 @@ if Code.ensure_loaded?(Redix) and Code.ensure_loaded?(:poolboy) do
     """
     @spec default_signing_key(Config.t()) :: binary
     def default_signing_key(config), do: derive_key(config.get_base_secret.(), "RedisStore HMAC")
-
-    ###########
-    # Private #
-    ###########
-
-    defp key_data(uid, type, mod_conf),
-      do: {to_string(uid), Atom.to_string(type), mod_conf.key_prefix}
-
-    # serialize and sign a session
-    defp serialize(session, %{get_signing_key: get_key}, config) do
-      session |> :erlang.term_to_binary() |> sign_hmac(get_key.(config))
-    end
-
-    # deserialize session and verify its signature
-    defp deserialize(nil, _, _), do: nil
-
-    defp deserialize(serialized, %{get_signing_key: get_key}, config) do
-      serialized
-      |> verify_hmac(get_key.(config))
-      |> case do
-        {:ok, serialized} ->
-          deserialize(serialized)
-
-        _ ->
-          Logger.warning("Ignored Redis session with invalid signature.")
-          nil
-      end
-    end
-
-    # deserialize a session, returning nil on errors
-    defp deserialize(serialized) do
-      try do
-        :erlang.binary_to_term(serialized)
-      rescue
-        _ -> nil
-      end
-    end
-
-    # key under which the actual session is stored
-    @doc false
-    def session_key(session_id, user_id, type, key_prefix),
-      do: [key_prefix, ".s.", user_id, ?., type, ?., session_id]
-
-    # key for the sorted-by-expiration-timestamp set of the user's session keys
-    @doc false
-    def set_key(user_id, "full", key_prefix), do: [key_prefix, ".u.", user_id]
-    def set_key(user_id, type, key_prefix), do: [key_prefix, ".u.", user_id, ?., type]
-
-    # get all keys, including expired ones, for a user
-    defp get_session_keys(user_id, type, key_prefix, mod_conf) do
-      # get all of the user's session keys (index 0 = first, -1 = last)
-      ["ZRANGE", set_key(user_id, type, key_prefix), "0", "-1"]
-      |> RedisClient.command(mod_conf.debug_log?)
-    end
-
-    # get all valid keys for a user
-    defp get_valid_session_keys(user_id, type, key_prefix, mod_conf) do
-      now = Internal.now() |> Integer.to_string()
-
-      # get all of the user's valid session keys (with score/timestamp >= now)
-      ["ZRANGE", set_key(user_id, type, key_prefix), now, "+inf", "BYSCORE"]
-      |> RedisClient.command(mod_conf.debug_log?)
-    end
-
-    # returns {session_exists?, exp_str}
-    defp parse_zrange_withscores(single_zrange_withscores_result)
-    defp parse_zrange_withscores([_session_key, exp_str]), do: {true, exp_str}
-    defp parse_zrange_withscores(_), do: {false, "0"}
-
-    # clean up the user's old sessions
-    defp prune_session_set_cmd(set_key, now_str),
-      do: ["ZREMRANGEBYSCORE", set_key, "-inf", now_str]
-
-    # grab the session key and score (= exp timestamp) of the highest-exp session of the user
-    defp get_max_exp_session_cmd(set_key) do
-      ["ZRANGE", set_key, "+inf", "-inf", "REV", "BYSCORE", "LIMIT", "0", "1", "WITHSCORES"]
-    end
-
-    # set the expiration time of the user's session set
-    defp put_s_exp_cmd(set_key, exp_str), do: ["EXPIREAT", set_key, exp_str]
-
-    defp put_s_exp(set_key, exp_str, mod_conf) do
-      put_s_exp_cmd(set_key, exp_str)
-      |> RedisClient.command(mod_conf.debug_log?)
-      |> case do
-        {:ok, _} -> :ok
-        error -> Logger.error("Error during user session set maintenance: #{inspect(error)}")
-      end
-    end
-
-    defp get_s_exp_cmd(set_key), do: ["EXPIRETIME", set_key]
-
-    defp redis_result_to_error({:ok, error}), do: {:error, inspect(error)}
-    defp redis_result_to_error(error), do: error
   end
 else
   defmodule Charon.SessionStore.RedisStore do
     @message "Optional dependencies `:redix` and `:poolboy` must be loaded to use this module."
     @moduledoc @message
 
-    def get(_, _, _, _), do: raise(message)
-    def upsert(_, _), do: raise(message)
-    def delete(_, _, _, _), do: raise(message)
-    def get_all(_, _, _), do: raise(message)
-    def delete_all(_, _, _), do: raise(message)
+    def get(_, _, _, _), do: raise(@message)
+    def upsert(_, _), do: raise(@message)
+    def delete(_, _, _, _), do: raise(@message)
+    def get_all(_, _, _), do: raise(@message)
+    def delete_all(_, _, _), do: raise(@message)
 
-    def init_config(_), do: raise(message)
-    def default_signing_key(_), do: raise(message)
+    def init_config(_), do: raise(@message)
+    def default_signing_key(_), do: raise(@message)
   end
 end

--- a/lib/charon/session_store/redis_store.ex
+++ b/lib/charon/session_store/redis_store.ex
@@ -18,6 +18,8 @@ if Code.ensure_loaded?(Redix) and Code.ensure_loaded?(:poolboy) do
     ## Redis requirements
 
     This module needs a Redis >= 7.0.0 instance and needs permissions to create Redis functions.
+    The optimistic-locking functionality of the store was not designed with a Redis cluster in mind
+    and will behave unpredictably when used with a distributed Redis deployment.
 
     ## Config
 

--- a/lib/charon/session_store/redis_store/config.ex
+++ b/lib/charon/session_store/redis_store/config.ex
@@ -5,13 +5,11 @@ defmodule Charon.SessionStore.RedisStore.Config do
   alias Charon.SessionStore.RedisStore
   @enforce_keys []
   defstruct key_prefix: "charon_",
-            get_signing_key: &RedisStore.default_signing_key/1,
-            debug_log?: false
+            get_signing_key: &RedisStore.default_signing_key/1
 
   @type t :: %__MODULE__{
           key_prefix: String.t(),
-          get_signing_key: (Charon.Config.t() -> binary()),
-          debug_log?: boolean
+          get_signing_key: (Charon.Config.t() -> binary())
         }
 
   @doc """

--- a/lib/charon/session_store/redis_store/lua_functions.ex
+++ b/lib/charon/session_store/redis_store/lua_functions.ex
@@ -1,0 +1,95 @@
+if Code.ensure_loaded?(Redix) and Code.ensure_loaded?(:poolboy) do
+  defmodule Charon.SessionStore.RedisStore.LuaFunctions do
+    @moduledoc false
+    require Logger
+
+    @doc """
+    Returns the Redis command to call Redis function "charon_resolve_set_exps",
+    which sets all set expiration timestamps to that of the max-exp session.
+
+    Returns `[n1, n2, n3]` with `n` being the EXPIREAT result.
+    """
+    @spec resolve_set_exps_cmd(iodata, iodata, iodata) :: [integer]
+    def resolve_set_exps_cmd(session_set_key, exp_oset_key, lock_set_key) do
+      call_redis_function_cmd(
+        "charon_resolve_set_exps",
+        [session_set_key, exp_oset_key, lock_set_key],
+        []
+      )
+    end
+
+    @doc """
+    Returns the Redis command to call Redis function "charon_opt_lock_upsert",
+    which upserts a session while optimistically locking on `lock_version`.
+    On a locking failure, `"CONFLICT"` is returned and no state is changed.
+
+    On a locking success:
+     - the serialized `session` is stored under its `sid` in `session_set_key`
+     - the session's `expires_at` value is stored under the session's `sid` in `exp_oset_key`
+     - the session's `lock_version` is stored under the session's `sid` in `lock_set_key`
+     - the expiration timestamp of all sets is increased to `expires_at`
+
+    Returns: `[n1, n2, n3, m1, m2, m3]` with n being the number of elements added to a respective set,
+    and m being the result of calling EXPIREAT (with GT modifier) on that set.
+    """
+    @spec opt_lock_upsert_cmd(iodata, iodata, iodata, iodata, integer, iodata, integer) ::
+            [integer] | binary()
+    def opt_lock_upsert_cmd(
+          session_set_key,
+          exp_oset_key,
+          lock_set_key,
+          sid,
+          lock_version,
+          session,
+          expires_at
+        ) do
+      call_redis_function_cmd(
+        "charon_opt_lock_upsert",
+        [session_set_key, exp_oset_key, lock_set_key],
+        [sid, lock_version, session, expires_at]
+      )
+    end
+
+    @doc """
+    Returns the Redis command to call Redis function "charon_maybe_prune_expired",
+    which prunes expired sessions from all session sets, once an hour max.
+
+    Returns `"SKIPPED"` when run again within an hour,
+    otherwise returns `[n1, n2, n3]` with `n` being the number of elements removed from a respective set.
+    """
+    @spec maybe_prune_expired_cmd(iodata, iodata, iodata, iodata, integer) :: [integer] | binary
+    def maybe_prune_expired_cmd(session_set_key, exp_oset_key, lock_set_key, prune_lock_key, now) do
+      call_redis_function_cmd(
+        "charon_maybe_prune_expired",
+        [session_set_key, exp_oset_key, lock_set_key, prune_lock_key],
+        [now]
+      )
+    end
+
+    @doc """
+    Returns the Redis command to call a Redis function with keys and args.
+    """
+    @spec call_redis_function_cmd(binary, list, list) :: any
+    def call_redis_function_cmd(name, keys, args) do
+      key_count = keys |> Enum.count() |> Integer.to_string()
+      ["FCALL", name, key_count] ++ keys ++ args
+    end
+
+    @doc """
+    Create a separate, out-of-pool redix connection and register the Redis Lua functions with it.
+    """
+    @spec register_functions(keyword) :: :ok
+    def register_functions(redix_opts) do
+      with <<priv_dir::binary>> <- :code.priv_dir(:charon) |> to_string(),
+           {:ok, script} <- File.read(priv_dir <> "/redis_functions.lua"),
+           {:ok, temp_redix} <- Redix.start_link(redix_opts),
+           load_function_command = ["FUNCTION", "LOAD", "REPLACE", script],
+           {:ok, "charon_redis_store"} <- Redix.command(temp_redix, load_function_command) do
+        Process.exit(temp_redix, :normal)
+        Logger.info("Redis functions registered successfully.")
+      else
+        error -> raise "Could not register Redis functions: #{inspect(error)}"
+      end
+    end
+  end
+end

--- a/lib/charon/session_store/redis_store/redis_client.ex
+++ b/lib/charon/session_store/redis_store/redis_client.ex
@@ -63,11 +63,11 @@ if Code.ensure_loaded?(Redix) and Code.ensure_loaded?(:poolboy) do
       result
     end
 
-    defp maybe_log(_result, _command, false), do: :ok
-
     defp maybe_log(result = {:error, _}, command, _) do
       Logger.error("Redis command #{inspect(command)}, result: #{inspect(result)}")
     end
+
+    defp maybe_log(_result, _command, false), do: :ok
 
     defp maybe_log(result, command, _) do
       Logger.debug(fn -> "Redis command #{inspect(command)}, result: #{inspect(result)}" end)

--- a/lib/charon/session_store/redis_store/redis_client.ex
+++ b/lib/charon/session_store/redis_store/redis_client.ex
@@ -15,17 +15,20 @@ if Code.ensure_loaded?(Redix) and Code.ensure_loaded?(:poolboy) do
     """
     @spec command(command, boolean, keyword) :: redix_result
     def command(command, debug_log? \\ false, redix_opts \\ []) do
-      ConnectionPool.transaction(&conn_command(&1, command, debug_log?, redix_opts))
+      ConnectionPool.transaction(&conn_command(command, &1, debug_log?, redix_opts))
     end
 
     @doc """
     Execute a Redis command using a previously checked-out connection.
 
-    Use `Charon.SessionStore.RedisStore.ConnectionPool.checkout/2` to get a connection,
-    and use `Charon.SessionStore.RedisStore.ConnectionPool.checkin/1` to return the connection to the pool.
+    Either use this command with the connection available inside
+    `Charon.SessionStore.RedisStore.ConnectionPool.transaction/2`,
+    or use `Charon.SessionStore.RedisStore.ConnectionPool.checkout/2` to get a connection,
+    combined with `Charon.SessionStore.RedisStore.ConnectionPool.checkin/1`
+    to return the connection to the pool.
     """
-    @spec conn_command(connection, command, boolean, keyword) :: redix_result
-    def conn_command(conn, command, debug_log? \\ false, redix_opts \\ []) do
+    @spec conn_command(command, connection, boolean, keyword) :: redix_result
+    def conn_command(command, conn, debug_log? \\ false, redix_opts \\ []) do
       Redix.command(conn, command, redix_opts) |> tap_maybe_log(command, debug_log?)
     end
 
@@ -34,17 +37,20 @@ if Code.ensure_loaded?(Redix) and Code.ensure_loaded?(:poolboy) do
     """
     @spec pipeline([command], boolean, keyword) :: redix_result
     def pipeline(commands, debug_log? \\ false, redix_opts \\ []) do
-      ConnectionPool.transaction(&conn_pipeline(&1, commands, debug_log?, redix_opts))
+      ConnectionPool.transaction(&conn_pipeline(commands, &1, debug_log?, redix_opts))
     end
 
     @doc """
     Execute a list of Redis commands using a previously checked-out connection.
 
-    Use `Charon.SessionStore.RedisStore.ConnectionPool.checkout/2` to get a connection,
-    and use `Charon.SessionStore.RedisStore.ConnectionPool.checkin/1` to return the connection to the pool.
+    Either use this command with the connection available inside
+    `Charon.SessionStore.RedisStore.ConnectionPool.transaction/2`,
+    or use `Charon.SessionStore.RedisStore.ConnectionPool.checkout/2` to get a connection,
+    combined with `Charon.SessionStore.RedisStore.ConnectionPool.checkin/1`
+    to return the connection to the pool.
     """
-    @spec conn_pipeline(connection, [command], boolean, keyword) :: redix_result
-    def conn_pipeline(conn, commands, debug_log? \\ false, redix_opts \\ []) do
+    @spec conn_pipeline([command], connection, boolean, keyword) :: redix_result
+    def conn_pipeline(commands, conn, debug_log? \\ false, redix_opts \\ []) do
       Redix.pipeline(conn, commands, redix_opts) |> tap_maybe_log(commands, debug_log?)
     end
 

--- a/lib/charon/session_store/redis_store/store_impl.ex
+++ b/lib/charon/session_store/redis_store/store_impl.ex
@@ -1,0 +1,202 @@
+if Code.ensure_loaded?(Redix) and Code.ensure_loaded?(:poolboy) do
+  defmodule Charon.SessionStore.RedisStore.StoreImpl do
+    @moduledoc false
+    alias Charon.SessionStore.Behaviour, as: SessionStoreBehaviour
+    @behaviour SessionStoreBehaviour
+    alias Charon.{Internal}
+    alias Charon.SessionStore.RedisStore.{RedisClient, LuaFunctions}
+    import Charon.SessionStore.RedisStore.Config, only: [get_mod_config: 1]
+    import Internal.Crypto
+    require Logger
+
+    @multi ~W(MULTI)
+    @exec ~W(EXEC)
+
+    @impl SessionStoreBehaviour
+    def get(session_id, user_id, type, config) do
+      mod_conf = get_mod_config(config)
+      session_set_key = key_data(user_id, type, mod_conf) |> session_set_key()
+
+      ["HGET", session_set_key, session_id]
+      |> RedisClient.command()
+      |> case do
+        {:ok, result} ->
+          result
+          |> deserialize(mod_conf, config)
+          |> validate(session_id, user_id, type, Internal.now())
+
+        error ->
+          error
+      end
+    end
+
+    @impl SessionStoreBehaviour
+    def upsert(_session = %{refresh_expires_at: exp, refreshed_at: now}, _config) when exp < now,
+      do: :ok
+
+    def upsert(
+          session = %{
+            id: sid,
+            lock_version: lock_version,
+            refresh_expires_at: exp,
+            refreshed_at: now,
+            type: type,
+            user_id: uid
+          },
+          config
+        ) do
+      mod_conf = get_mod_config(config)
+      key_data = key_data(uid, type, mod_conf)
+      session_set_key = session_set_key(key_data)
+      exp_oset_key = exp_oset_key(key_data)
+      lock_set_key = lock_set_key(key_data)
+      prune_lock_key = prune_lock_key(key_data)
+
+      new_lock_version = lock_version + 1
+      serialized = %{session | lock_version: new_lock_version} |> serialize(mod_conf, config)
+
+      [
+        LuaFunctions.opt_lock_upsert_cmd(
+          session_set_key,
+          exp_oset_key,
+          lock_set_key,
+          sid,
+          new_lock_version,
+          serialized,
+          exp
+        ),
+        LuaFunctions.maybe_prune_expired_cmd(
+          session_set_key,
+          exp_oset_key,
+          lock_set_key,
+          prune_lock_key,
+          now
+        )
+      ]
+      |> RedisClient.pipeline()
+      |> case do
+        {:ok, ["CONFLICT", _]} -> {:error, :conflict}
+        {:ok, [[_, _, _, _, _, _], _]} -> :ok
+        error -> redis_result_to_error(error)
+      end
+    end
+
+    @impl SessionStoreBehaviour
+    def delete(session_id, user_id, type, config) do
+      mod_conf = get_mod_config(config)
+      key_data = key_data(user_id, type, mod_conf)
+      session_set_key = session_set_key(key_data)
+      lock_set_key = lock_set_key(key_data)
+      exp_oset_key = exp_oset_key(key_data)
+
+      [
+        @multi,
+        ["HDEL", session_set_key, session_id],
+        ["HDEL", lock_set_key, session_id],
+        ["ZREM", exp_oset_key, session_id],
+        LuaFunctions.resolve_set_exps_cmd(session_set_key, exp_oset_key, lock_set_key),
+        @exec
+      ]
+      |> RedisClient.pipeline()
+      |> case do
+        {:ok, [_, _, _, _, _, transaction_res]} when is_list(transaction_res) -> :ok
+        error -> redis_result_to_error(error)
+      end
+    end
+
+    @impl SessionStoreBehaviour
+    def get_all(user_id, type, config) do
+      mod_conf = get_mod_config(config)
+      key_data = key_data(user_id, type, mod_conf)
+      session_set_key = session_set_key(key_data)
+      now = Internal.now()
+
+      with {:ok, values} <- RedisClient.command(["HVALS", session_set_key]) do
+        values
+        |> Stream.map(&(&1 |> deserialize(mod_conf, config) |> validate(user_id, type, now)))
+        |> Enum.reject(&is_nil/1)
+      else
+        {:ok, []} -> []
+        other -> other
+      end
+    end
+
+    @impl SessionStoreBehaviour
+    def delete_all(user_id, type, config) do
+      mod_conf = get_mod_config(config)
+      key_data = key_data(user_id, type, mod_conf)
+      exp_oset_key = exp_oset_key(key_data)
+      session_set_key = session_set_key(key_data)
+      lock_set_key = lock_set_key(key_data)
+
+      with {:ok, _} <- RedisClient.command(["DEL", exp_oset_key, session_set_key, lock_set_key]) do
+        :ok
+      else
+        error -> redis_result_to_error(error)
+      end
+    end
+
+    ###########
+    # Private #
+    ###########
+
+    defp key_data(uid, type, mod_conf),
+      do: {to_string(uid), Atom.to_string(type), mod_conf.key_prefix}
+
+    # serialize and sign a session
+    defp serialize(session, %{get_signing_key: get_key}, config) do
+      session |> :erlang.term_to_binary() |> sign_hmac(get_key.(config))
+    end
+
+    # deserialize session and verify its signature
+    defp deserialize(nil, _, _), do: nil
+
+    defp deserialize(serialized, %{get_signing_key: get_key}, config) do
+      serialized
+      |> verify_hmac(get_key.(config))
+      |> case do
+        {:ok, verified_binary} ->
+          :erlang.binary_to_term(verified_binary)
+
+        _ ->
+          Logger.warning("Ignored Redis session with invalid signature.")
+          nil
+      end
+    end
+
+    defp validate(session, uid, type, now) do
+      case session do
+        s = %{refresh_expires_at: exp, user_id: ^uid, type: ^type} when exp >= now -> s
+        _ -> nil
+      end
+    end
+
+    defp validate(session, sid, uid, type, now) do
+      case validate(session, uid, type, now) do
+        s = %{id: ^sid} -> s
+        _ -> nil
+      end
+    end
+
+    # key for the sorted-by-expiration-timestamp set of the user's session keys
+    @doc false
+    # the expiration ordered set stores sids and expiration timestamps sorted by the timestamp
+    def exp_oset_key({uid, type, prefix}), do: to_key(uid, type, prefix, "e")
+
+    @doc false
+    # the session set maps sid's to sessions
+    def session_set_key({uid, type, prefix}), do: to_key(uid, type, prefix, "s")
+
+    @doc false
+    # the lock set maps sid's to session lock_version values
+    def lock_set_key({uid, type, prefix}), do: to_key(uid, type, prefix, "l")
+
+    # create a key from a user_id, sessions type, prefix, and separator
+    defp to_key(uid, type, prefix, sep), do: [prefix, ?., sep, ?., uid, ?., type]
+
+    defp prune_lock_key({uid, type, prefix}), do: to_key(uid, type, prefix, "pl")
+
+    defp redis_result_to_error({:ok, error}), do: {:error, inspect(error)}
+    defp redis_result_to_error(error), do: error
+  end
+end

--- a/lib/charon/session_store/redis_store/store_impl.ex
+++ b/lib/charon/session_store/redis_store/store_impl.ex
@@ -20,9 +20,10 @@ if Code.ensure_loaded?(Redix) and Code.ensure_loaded?(:poolboy) do
       ["HGET", session_set_key, session_id]
       |> RedisClient.command()
       |> case do
-        {:ok, result} ->
-          result
-          |> deserialize(mod_conf, config)
+        {:ok, nil_or_binary} ->
+          nil_or_binary
+          |> verify(mod_conf, config)
+          |> maybe_deserialize()
           |> validate(session_id, user_id, type, Internal.now())
 
         error ->
@@ -53,7 +54,8 @@ if Code.ensure_loaded?(Redix) and Code.ensure_loaded?(:poolboy) do
       prune_lock_key = prune_lock_key(key_data)
 
       new_lock_version = lock_version + 1
-      serialized = %{session | lock_version: new_lock_version} |> serialize(mod_conf, config)
+      session = %{session | lock_version: new_lock_version}
+      serialized_signed = session |> serialize() |> sign(mod_conf, config)
 
       [
         LuaFunctions.opt_lock_upsert_cmd(
@@ -62,7 +64,7 @@ if Code.ensure_loaded?(Redix) and Code.ensure_loaded?(:poolboy) do
           lock_set_key,
           sid,
           new_lock_version,
-          serialized,
+          serialized_signed,
           exp
         ),
         LuaFunctions.maybe_prune_expired_cmd(
@@ -113,7 +115,12 @@ if Code.ensure_loaded?(Redix) and Code.ensure_loaded?(:poolboy) do
 
       with {:ok, values} <- RedisClient.command(["HVALS", session_set_key]) do
         values
-        |> Stream.map(&(&1 |> deserialize(mod_conf, config) |> validate(user_id, type, now)))
+        |> Stream.map(fn nil_or_binary ->
+          nil_or_binary
+          |> verify(mod_conf, config)
+          |> maybe_deserialize()
+          |> validate(user_id, type, now)
+        end)
         |> Enum.reject(&is_nil/1)
       else
         {:ok, []} -> []
@@ -140,30 +147,32 @@ if Code.ensure_loaded?(Redix) and Code.ensure_loaded?(:poolboy) do
     # Private #
     ###########
 
+    # create redis key data
     defp key_data(uid, type, mod_conf),
       do: {to_string(uid), Atom.to_string(type), mod_conf.key_prefix}
 
-    # serialize and sign a session
-    defp serialize(session, %{get_signing_key: get_key}, config) do
-      session |> :erlang.term_to_binary() |> sign_hmac(get_key.(config))
+    defp serialize(session), do: :erlang.term_to_binary(session)
+
+    # sign a binary with a prefixed hmac
+    defp sign(serialized, %{get_signing_key: get_key}, config),
+      do: sign_hmac(serialized, get_key.(config))
+
+    # verify the prefixed hmac of a binary
+    defp verify(nil, _, _), do: nil
+
+    defp verify(serialized, %{get_signing_key: get_key}, config),
+      do: verify_hmac(serialized, get_key.(config))
+
+    # deserialize the result of verify/3, when valid
+    defp maybe_deserialize({:ok, verified}), do: :erlang.binary_to_term(verified)
+    defp maybe_deserialize(nil), do: nil
+
+    defp maybe_deserialize(_) do
+      Logger.warning("Ignored Redis session with invalid signature.")
+      nil
     end
 
-    # deserialize session and verify its signature
-    defp deserialize(nil, _, _), do: nil
-
-    defp deserialize(serialized, %{get_signing_key: get_key}, config) do
-      serialized
-      |> verify_hmac(get_key.(config))
-      |> case do
-        {:ok, verified_binary} ->
-          :erlang.binary_to_term(verified_binary)
-
-        _ ->
-          Logger.warning("Ignored Redis session with invalid signature.")
-          nil
-      end
-    end
-
+    # validate that session matches uid, type and is not expired
     defp validate(session, uid, type, now) do
       case session do
         s = %{refresh_expires_at: exp, user_id: ^uid, type: ^type} when exp >= now -> s
@@ -171,6 +180,7 @@ if Code.ensure_loaded?(Redix) and Code.ensure_loaded?(:poolboy) do
       end
     end
 
+    # validate that session matches sid, uid, type and is not expired
     defp validate(session, sid, uid, type, now) do
       case validate(session, uid, type, now) do
         s = %{id: ^sid} -> s
@@ -194,8 +204,10 @@ if Code.ensure_loaded?(Redix) and Code.ensure_loaded?(:poolboy) do
     # create a key from a user_id, sessions type, prefix, and separator
     defp to_key(uid, type, prefix, sep), do: [prefix, ?., sep, ?., uid, ?., type]
 
+    # the prune lock makes sure that expired sessions are only pruned once an hour
     defp prune_lock_key({uid, type, prefix}), do: to_key(uid, type, prefix, "pl")
 
+    # transforms an {:ok, _} result into an {:error, _} result
     defp redis_result_to_error({:ok, error}), do: {:error, inspect(error)}
     defp redis_result_to_error(error), do: error
   end

--- a/lib/charon/session_store/redis_store/store_impl.ex
+++ b/lib/charon/session_store/redis_store/store_impl.ex
@@ -195,7 +195,7 @@ if Code.ensure_loaded?(Redix) and Code.ensure_loaded?(:poolboy) do
 
     @doc false
     # the session set maps sid's to sessions
-    def session_set_key({uid, type, prefix}), do: to_key(uid, type, prefix, "s")
+    def session_set_key({uid, type, prefix}), do: to_key(uid, type, prefix, "se")
 
     @doc false
     # the lock set maps sid's to session lock_version values

--- a/priv/redis_functions.lua
+++ b/priv/redis_functions.lua
@@ -1,0 +1,101 @@
+#!lua name=charon_redis_store
+
+-------------
+-- PRIVATE --
+-------------
+
+local function map(enumerable, func)
+  local results = {}
+  for i=1, #enumerable do
+    results[i] = func(enumerable[i])
+  end
+  return results
+end
+
+local function expire_all(keys, at)
+  return map(keys, function (v) return redis.call("EXPIREAT", v, at) end)
+end
+
+-- remove sids of expired sessions from all sets
+local function prune_expired(session_set_key, exp_oset_key, lock_set_key, now)
+  local expired = redis.call("ZRANGE", exp_oset_key, "-inf", "("..now, "BYSCORE")
+
+  if #expired == 0 then
+    return {0, 0, 0}
+  else
+    return {
+      redis.call("HDEL", session_set_key, unpack(expired)),
+      redis.call("ZREM", exp_oset_key, unpack(expired)),
+      redis.call("HDEL", lock_set_key, unpack(expired))
+    }
+  end
+end
+
+-- stupid EXPIREAT GT does not work if the key doesn't exist :|
+local function incr_exp(key, new_max)
+  local current_exp = redis.call("EXPIRETIME", key)
+  -- the key does not exist if current_exp == -2
+  if current_exp ~= -2 and new_max > current_exp then
+    return redis.call("EXPIREAT", key, new_max)
+  else
+    return 0
+  end
+end
+
+local function incr_exps(keys, new_max)
+  return map(keys, function (v) return incr_exp(v, new_max) end)
+end
+
+------------
+-- PUBLIC --
+------------
+
+-- grab max exp from expiration set and update all relevant set expiration values to it
+local function resolve_set_exps(keys, args)
+  local session_set_key, exp_oset_key, lock_set_key = unpack(keys)
+
+  local _, score = unpack(redis.call("ZRANGE", exp_oset_key, "+inf", "-inf", "REV", "BYSCORE", "LIMIT", "0", "1", "WITHSCORES"))
+
+  if score then
+    return expire_all({session_set_key, exp_oset_key, lock_set_key}, score)
+  else
+    return {0, 0, 0}
+  end
+end
+
+-- upsert a session if its lock_version is not stale
+-- the function expects to be called with an *increased* lock version
+local function opt_lock_upsert(keys, args)
+  local session_set_key, exp_oset_key, lock_set_key = unpack(keys)
+  local sid, lock_version, session, expires_at = unpack(args)
+
+  local current_lock = redis.call("HGET", lock_set_key, sid)
+
+  -- if current_lock exists, this is an update, not an insert
+  if current_lock and current_lock + 1 ~= tonumber(lock_version) then
+    return "CONFLICT"
+  else
+    return {
+      redis.call("HSET", session_set_key, sid, session),
+      redis.call("ZADD", exp_oset_key, expires_at, sid),
+      redis.call("HSET", lock_set_key, sid, lock_version),
+      unpack(incr_exps({session_set_key, exp_oset_key, lock_set_key}, tonumber(expires_at)))
+    }
+  end
+end
+
+-- prune_expired wrapped in a once-per-hour-mechanism based on a locking key
+local function maybe_prune_expired(keys, args)
+  local session_set_key, exp_oset_key, lock_set_key, prune_lock_key = unpack(keys)
+
+  if redis.call("SET", prune_lock_key, "1", "NX", "GET", "EX", 3600) then
+    return "SKIPPED"
+  else
+    local now = unpack(args)
+    return prune_expired(session_set_key, exp_oset_key, lock_set_key, now)
+  end
+end
+
+redis.register_function('charon_resolve_set_exps', resolve_set_exps)
+redis.register_function('charon_opt_lock_upsert', opt_lock_upsert)
+redis.register_function('charon_maybe_prune_expired', maybe_prune_expired)

--- a/priv/redis_functions.lua
+++ b/priv/redis_functions.lua
@@ -1,4 +1,4 @@
-#!lua name=charon_redis_store
+#!lua name=charon_redis_store_0.0.0+development
 
 -------------
 -- PRIVATE --
@@ -94,6 +94,6 @@ local function maybe_prune_expired(keys, args)
   end
 end
 
-redis.register_function('charon_resolve_set_exps', resolve_set_exps)
-redis.register_function('charon_opt_lock_upsert', opt_lock_upsert)
-redis.register_function('charon_maybe_prune_expired', maybe_prune_expired)
+redis.register_function('resolve_set_exps_0.0.0+development', resolve_set_exps)
+redis.register_function('opt_lock_upsert_0.0.0+development', opt_lock_upsert)
+redis.register_function('maybe_prune_expired_0.0.0+development', maybe_prune_expired)

--- a/test/charon/config_test.exs
+++ b/test/charon/config_test.exs
@@ -28,8 +28,7 @@ defmodule Charon.ConfigTest do
     },
     RedisStore.Config => %{
       key_prefix: "charon_",
-      get_signing_key: &RedisStore.default_signing_key/1,
-      debug_log?: false
+      get_signing_key: &RedisStore.default_signing_key/1
     }
   }
 

--- a/test/charon/session_store/redis_store/lua_functions_test.exs
+++ b/test/charon/session_store/redis_store/lua_functions_test.exs
@@ -1,0 +1,279 @@
+defmodule Charon.SessionStore.RedisStore.LuaFunctionsTest do
+  use ExUnit.Case
+  alias Charon.SessionStore.RedisStore
+  alias RedisStore.{LuaFunctions, RedisClient}
+  alias Charon.Internal
+
+  @ttl 10
+  @now Internal.now()
+  @exp @now + @ttl
+  @exp_str to_string(@exp)
+  @sid "a"
+  @exp_oset_key "exp_oset"
+  @session_set_key "session_set"
+  @lock_set_key "lock_set"
+  @prune_lock_key "prune_lock"
+
+  defp to_result({:ok, result}), do: result
+  defp exec_cmd(cmd), do: cmd |> RedisClient.command() |> to_result()
+  defp add_hash_set(set_k, k, v), do: ["HSET", set_k, k, v] |> exec_cmd()
+  defp add_sort_set(set_k, k, s), do: ["ZADD", set_k, s, k] |> exec_cmd()
+  defp get_exp(key), do: ["EXPIRETIME", key] |> exec_cmd()
+  defp set_exp(key, exp), do: 1 = ["EXPIREAT", key, exp] |> exec_cmd()
+
+  setup_all do
+    redix_opts = [host: System.get_env("REDIS_HOSTNAME", "localhost")]
+    start_supervised!({RedisStore, redix_opts: redix_opts})
+    :ok
+  end
+
+  setup do
+    RedisClient.command(~w(FLUSHDB))
+    :ok
+  end
+
+  describe "resolve_set_exps_cmd" do
+    test "works when nothing found" do
+      assert [0, 0, 0] =
+               LuaFunctions.resolve_set_exps_cmd(@session_set_key, @exp_oset_key, @lock_set_key)
+               |> exec_cmd()
+    end
+
+    test "works when only expiration set found" do
+      add_sort_set(@exp_oset_key, @sid, @exp)
+      add_sort_set(@exp_oset_key, "other", @exp - 5)
+
+      assert [0, 1, 0] =
+               LuaFunctions.resolve_set_exps_cmd(@session_set_key, @exp_oset_key, @lock_set_key)
+               |> exec_cmd()
+
+      assert @exp == get_exp(@exp_oset_key)
+    end
+
+    test "works when only session set found" do
+      add_hash_set(@session_set_key, @sid, "session")
+
+      assert [0, 0, 0] =
+               LuaFunctions.resolve_set_exps_cmd(@session_set_key, @exp_oset_key, @lock_set_key)
+               |> exec_cmd()
+
+      assert -1 == get_exp(@session_set_key)
+    end
+
+    test "sets session set, exp set and lock set expiration" do
+      add_hash_set(@session_set_key, @sid, "session")
+      add_sort_set(@exp_oset_key, @sid, @exp)
+      add_sort_set(@exp_oset_key, "other", @exp - 5)
+      add_hash_set(@lock_set_key, @sid, 5)
+
+      assert [1, 1, 1] =
+               LuaFunctions.resolve_set_exps_cmd(@session_set_key, @exp_oset_key, @lock_set_key)
+               |> exec_cmd()
+
+      assert @exp == get_exp(@session_set_key)
+      assert @exp == get_exp(@exp_oset_key)
+      assert @exp == get_exp(@lock_set_key)
+    end
+
+    test "works with negative exp (deletes sets)" do
+      add_hash_set(@session_set_key, @sid, "session")
+      add_sort_set(@exp_oset_key, "other", @now - 5)
+      add_hash_set(@lock_set_key, @sid, 5)
+
+      assert [1, 1, 1] =
+               LuaFunctions.resolve_set_exps_cmd(@session_set_key, @exp_oset_key, @lock_set_key)
+               |> exec_cmd()
+
+      assert -2 == get_exp(@session_set_key)
+      assert -2 == get_exp(@exp_oset_key)
+      assert -2 == get_exp(@lock_set_key)
+    end
+  end
+
+  describe "opt_lock_upsert" do
+    test "inserts new" do
+      assert [1, 1, 1, 1, 1, 1] =
+               LuaFunctions.opt_lock_upsert_cmd(
+                 @session_set_key,
+                 @exp_oset_key,
+                 @lock_set_key,
+                 @sid,
+                 0,
+                 "session",
+                 @exp
+               )
+               |> exec_cmd()
+
+      assert [@sid, "session"] == exec_cmd(["HGETALL", @session_set_key])
+      assert [@sid, "0"] == exec_cmd(["HGETALL", @lock_set_key])
+      assert [@sid, @exp_str] == exec_cmd(["ZRANGE", @exp_oset_key, 0, -1, "WITHSCORES"])
+      assert @exp == get_exp(@session_set_key)
+      assert @exp == get_exp(@exp_oset_key)
+      assert @exp == get_exp(@lock_set_key)
+    end
+
+    test "returns error on lock conflict" do
+      add_hash_set(@session_set_key, @sid, "session")
+      set_exp(@session_set_key, @exp)
+      add_hash_set(@lock_set_key, @sid, 0)
+      set_exp(@lock_set_key, @exp)
+      add_sort_set(@exp_oset_key, @sid, @exp)
+      set_exp(@exp_oset_key, @exp)
+
+      assert "CONFLICT" =
+               LuaFunctions.opt_lock_upsert_cmd(
+                 @session_set_key,
+                 @exp_oset_key,
+                 @lock_set_key,
+                 @sid,
+                 0,
+                 "new_session",
+                 @exp + 10
+               )
+               |> exec_cmd()
+
+      assert [@sid, "session"] == exec_cmd(["HGETALL", @session_set_key])
+      assert [@sid, "0"] == exec_cmd(["HGETALL", @lock_set_key])
+      assert [@sid, @exp_str] == exec_cmd(["ZRANGE", @exp_oset_key, 0, -1, "WITHSCORES"])
+      assert @exp == get_exp(@session_set_key)
+      assert @exp == get_exp(@exp_oset_key)
+      assert @exp == get_exp(@lock_set_key)
+    end
+
+    test "updates when lock ok" do
+      add_hash_set(@session_set_key, @sid, "session")
+      set_exp(@session_set_key, @exp)
+      add_hash_set(@lock_set_key, @sid, 0)
+      set_exp(@lock_set_key, @exp)
+      add_sort_set(@exp_oset_key, @sid, @exp)
+      set_exp(@exp_oset_key, @exp)
+
+      assert [0, 0, 0, 1, 1, 1] =
+               LuaFunctions.opt_lock_upsert_cmd(
+                 @session_set_key,
+                 @exp_oset_key,
+                 @lock_set_key,
+                 @sid,
+                 1,
+                 "new_session",
+                 @exp + 10
+               )
+               |> exec_cmd()
+
+      assert [@sid, "new_session"] == exec_cmd(["HGETALL", @session_set_key])
+      assert [@sid, "1"] == exec_cmd(["HGETALL", @lock_set_key])
+      assert [@sid, "#{@exp + 10}"] == exec_cmd(["ZRANGE", @exp_oset_key, 0, -1, "WITHSCORES"])
+      assert @exp + 10 == get_exp(@session_set_key)
+      assert @exp + 10 == get_exp(@exp_oset_key)
+      assert @exp + 10 == get_exp(@lock_set_key)
+    end
+
+    test "only increases set exps" do
+      add_hash_set(@session_set_key, @sid, "session")
+      set_exp(@session_set_key, @exp + 10)
+      add_hash_set(@lock_set_key, @sid, 0)
+      set_exp(@lock_set_key, @exp + 10)
+      add_sort_set(@exp_oset_key, @sid, @exp)
+      set_exp(@exp_oset_key, @exp + 10)
+
+      assert [0, 0, 0, 0, 0, 0] =
+               LuaFunctions.opt_lock_upsert_cmd(
+                 @session_set_key,
+                 @exp_oset_key,
+                 @lock_set_key,
+                 @sid,
+                 1,
+                 "new_session",
+                 @exp + 5
+               )
+               |> exec_cmd()
+
+      assert [@sid, "new_session"] == exec_cmd(["HGETALL", @session_set_key])
+      assert [@sid, "1"] == exec_cmd(["HGETALL", @lock_set_key])
+      assert [@sid, "#{@exp + 5}"] == exec_cmd(["ZRANGE", @exp_oset_key, 0, -1, "WITHSCORES"])
+      assert @exp + 10 == get_exp(@session_set_key)
+      assert @exp + 10 == get_exp(@exp_oset_key)
+      assert @exp + 10 == get_exp(@lock_set_key)
+    end
+  end
+
+  describe "maybe_prune_expired" do
+    test "works with missing keys" do
+      assert [0, 0, 0] =
+               LuaFunctions.maybe_prune_expired_cmd(
+                 @session_set_key,
+                 @exp_oset_key,
+                 @lock_set_key,
+                 @prune_lock_key,
+                 @now
+               )
+               |> exec_cmd()
+    end
+
+    test "sets lock" do
+      LuaFunctions.maybe_prune_expired_cmd(
+        @session_set_key,
+        @exp_oset_key,
+        @lock_set_key,
+        @prune_lock_key,
+        @now
+      )
+      |> exec_cmd()
+
+      assert "1" = ["GET", @prune_lock_key] |> exec_cmd()
+    end
+
+    test "prunes expired sessions from all sets" do
+      add_hash_set(@session_set_key, @sid, "session")
+      add_hash_set(@session_set_key, "expired_session_sid", "session")
+      add_hash_set(@lock_set_key, @sid, 0)
+      add_hash_set(@lock_set_key, "expired_session_sid", 0)
+      add_sort_set(@exp_oset_key, @sid, @exp)
+      add_sort_set(@exp_oset_key, "expired_session_sid", @now - 5)
+
+      assert [1, 1, 1] =
+               LuaFunctions.maybe_prune_expired_cmd(
+                 @session_set_key,
+                 @exp_oset_key,
+                 @lock_set_key,
+                 @prune_lock_key,
+                 @now
+               )
+               |> exec_cmd()
+
+      assert [@sid, "session"] == exec_cmd(["HGETALL", @session_set_key])
+      assert [@sid, "0"] == exec_cmd(["HGETALL", @lock_set_key])
+      assert [@sid, @exp_str] == exec_cmd(["ZRANGE", @exp_oset_key, 0, -1, "WITHSCORES"])
+    end
+
+    test "skips operation if too recent" do
+      add_hash_set(@session_set_key, @sid, "session")
+      add_hash_set(@session_set_key, "expired_session_sid", "session")
+      add_hash_set(@lock_set_key, @sid, 0)
+      add_hash_set(@lock_set_key, "expired_session_sid", 0)
+      add_sort_set(@exp_oset_key, @sid, @exp)
+      add_sort_set(@exp_oset_key, "expired_session_sid", @now - 5)
+
+      # lock!
+      ["SET", @prune_lock_key, "1"] |> exec_cmd()
+
+      assert "SKIPPED" =
+               LuaFunctions.maybe_prune_expired_cmd(
+                 @session_set_key,
+                 @exp_oset_key,
+                 @lock_set_key,
+                 @prune_lock_key,
+                 @now
+               )
+               |> exec_cmd()
+
+      assert [@sid, "session", "expired_session_sid", "session"] ==
+               exec_cmd(["HGETALL", @session_set_key])
+
+      assert [@sid, "0", "expired_session_sid", "0"] == exec_cmd(["HGETALL", @lock_set_key])
+
+      assert ["expired_session_sid", "#{@now - 5}", @sid, @exp_str] ==
+               exec_cmd(["ZRANGE", @exp_oset_key, 0, -1, "WITHSCORES"])
+    end
+  end
+end

--- a/test/charon/session_store/redis_store/redis_client_test.exs
+++ b/test/charon/session_store/redis_store/redis_client_test.exs
@@ -19,14 +19,14 @@ defmodule Charon.SessionStore.RedisStore.RedisClientTest do
       conn_a = ConnectionPool.checkout()
 
       # setup optimistic_locking
-      {:ok, _} = RedisClient.conn_pipeline(conn_a, [~w(watch key)])
+      {:ok, _} = RedisClient.conn_pipeline([~w(watch key)], conn_a)
 
       # mess it up
       {:ok, _} = RedisClient.command(~w(set key boom))
 
       # watch it burn
       assert {:ok, [_, _, nil]} =
-               RedisClient.conn_pipeline(conn_a, [~w(multi), ~w(set key other_value), ~w(exec)])
+               RedisClient.conn_pipeline([~w(multi), ~w(set key other_value), ~w(exec)], conn_a)
     end
 
     test "works on no conflict" do
@@ -34,25 +34,29 @@ defmodule Charon.SessionStore.RedisStore.RedisClientTest do
       conn_a = ConnectionPool.checkout()
 
       # setup optimistic_locking
-      {:ok, _} = RedisClient.conn_pipeline(conn_a, [~w(watch key)])
+      {:ok, _} = RedisClient.conn_pipeline([~w(watch key)], conn_a)
 
       assert {:ok, [_, _, ["OK"]]} =
-               RedisClient.conn_pipeline(conn_a, [~w(multi), ~w(set key other_value), ~w(exec)])
+               RedisClient.conn_pipeline([~w(multi), ~w(set key other_value), ~w(exec)], conn_a)
 
       {:ok, "other_value"} = RedisClient.command(~w(get key))
     end
   end
 
-  test "worker returns to pool on parent process death" do
+  test "a new worker is added to the pool if it dies somehow" do
     assert %{available_workers: 10} = ConnectionPool.status()
 
     fn ->
       _conn = ConnectionPool.checkout()
       assert %{available_workers: 9} = ConnectionPool.status()
       # this process forgets to return the worker to the pool, which is bad
+      # it dies with the process
     end
     |> Task.async()
     |> Task.await()
+
+    # it may take a while for the pool to create a new worker
+    Process.sleep(50)
 
     assert %{available_workers: 10} = ConnectionPool.status()
   end

--- a/test/charon/session_store/redis_store_test.exs
+++ b/test/charon/session_store/redis_store_test.exs
@@ -106,6 +106,13 @@ defmodule Charon.SessionStore.RedisStoreTest do
                refute RedisStore.get(@sid, @uid, :full, @config)
              end) =~ "Ignored Redis session"
     end
+
+    test "ignores valid session with mismatching properties" do
+      # another user's session somehow ends up in this user's session set
+      invalid = serialize(%{@user_session | user_id: @uid + 1}) |> sign()
+      add_session_set(@sid, invalid)
+      refute RedisStore.get(@sid, @uid, :full, @config)
+    end
   end
 
   describe "upsert/3" do

--- a/test/charon/session_store/redis_store_test.exs
+++ b/test/charon/session_store/redis_store_test.exs
@@ -5,9 +5,8 @@ defmodule Charon.SessionStore.RedisStoreTest do
   import Charon.{TestUtils, Internal}
   import Charon.Internal.Crypto
   alias Charon.{TestConfig}
-  alias RedisStore.{RedisClient, ConnectionPool}
+  alias RedisStore.{RedisClient}
   import RedisClient, only: [command: 1]
-  import Mock
 
   @ttl 10
   @now now()
@@ -28,13 +27,14 @@ defmodule Charon.SessionStore.RedisStoreTest do
                   refresh_expires_at: @exp,
                   refreshed_at: @now
                 )
-  @key session_key(@sid, @uid)
-  @set_key user_sessions_key(@uid)
+  @session_set_key session_set_key(@uid)
+  @exp_oset_key exp_oset_key(@uid)
+  @lock_set_key lock_set_key(@uid)
   @lock_incr_user_session %{@user_session | lock_version: 1}
 
   setup_all do
     redix_opts = [host: System.get_env("REDIS_HOSTNAME", "localhost")]
-    start_supervised!({ConnectionPool, redix_opts: redix_opts})
+    start_supervised!({RedisStore, redix_opts: redix_opts})
     :ok
   end
 
@@ -45,16 +45,34 @@ defmodule Charon.SessionStore.RedisStoreTest do
 
   defp serialize(session), do: session |> :erlang.term_to_binary()
   defp sign(binary), do: sign_hmac(binary, RedisStore.default_signing_key(@config))
-  defp get(key), do: command(["GET", key]) |> to_result()
-  defp list_set_values(key), do: command(["ZRANGE", key, 0, -1, "WITHSCORES"]) |> to_result()
+  # defp get(key), do: command(["GET", key]) |> to_result()
+  defp list_oset_values(key), do: command(["ZRANGE", key, 0, -1, "WITHSCORES"]) |> to_result()
+  defp list_hset_values(key), do: command(["HGETALL", key]) |> to_result()
   defp to_result({:ok, result}), do: result
   defp get_exp(key), do: command(["EXPIRETIME", key]) |> to_result()
   defp set_exp(key, exp), do: 1 = command(["EXPIREAT", key, exp]) |> to_result()
-  defp add_to_set(set_k, score, v), do: 1 = command(["ZADD", set_k, score, v]) |> to_result()
-  defp insert(key, value), do: "OK" = command(["SET", key, value]) |> to_result()
+  defp add_to_oset(set_k, score, v), do: 1 = command(["ZADD", set_k, score, v]) |> to_result()
+  defp add_to_hash_set(set_k, k, v), do: 1 = command(["HSET", set_k, k, v]) |> to_result()
+  defp add_session_set(k, v), do: add_to_hash_set(@session_set_key, k, v)
+  defp get_hash_set(set_k, k), do: command(["HGET", set_k, k]) |> to_result()
+  defp get_session_set(k), do: get_hash_set(@session_set_key, k)
+  defp get_lock_set(k), do: get_hash_set(@lock_set_key, k)
 
-  defp insert(session = %{id: sid, user_id: uid, type: type}) do
-    insert(session_key(sid, uid, type), session |> serialize() |> sign())
+  # defp insert(key, value), do: "OK" = command(["SET", key, value]) |> to_result()
+
+  defp insert(
+         session = %{
+           id: sid,
+           user_id: uid,
+           type: type,
+           lock_version: lock,
+           refresh_expires_at: exp
+         }
+       ) do
+    serialized_signed = session |> serialize() |> sign()
+    add_to_hash_set(session_set_key(uid, type), sid, serialized_signed)
+    add_to_hash_set(lock_set_key(uid, type), sid, lock)
+    add_to_oset(exp_oset_key(uid, type), exp, sid)
   end
 
   describe "get/4" do
@@ -73,7 +91,7 @@ defmodule Charon.SessionStore.RedisStoreTest do
     end
 
     test "ignores unsigned session" do
-      insert(@key, serialize(@user_session))
+      add_session_set(@sid, serialize(@user_session))
 
       assert capture_log(fn ->
                refute RedisStore.get(@sid, @uid, :full, @config)
@@ -82,7 +100,7 @@ defmodule Charon.SessionStore.RedisStoreTest do
 
     test "ignores signed session with invalid signature" do
       invalid = "signed." <> :crypto.strong_rand_bytes(32) <> "." <> serialize(@user_session)
-      insert(@key, invalid)
+      add_session_set(@sid, invalid)
 
       assert capture_log(fn ->
                refute RedisStore.get(@sid, @uid, :full, @config)
@@ -91,36 +109,31 @@ defmodule Charon.SessionStore.RedisStoreTest do
   end
 
   describe "upsert/3" do
-    test "stores session and adds key to user's set of sessions" do
+    test "stores session, lock and exp" do
       assert :ok = RedisStore.upsert(@user_session, @config)
-      assert @lock_incr_user_session |> serialize() |> sign() == get(@key)
-      assert [@key, _] = list_set_values(user_sessions_key(@uid))
+      assert @lock_incr_user_session |> serialize() |> sign() == get_session_set(@sid)
+      assert "1" == get_lock_set(@sid)
+      assert [@sid, @exp_str] == list_oset_values(@exp_oset_key)
     end
 
-    test "sets ttl / exp score" do
+    test "sets session sets ttl / exp score" do
       assert :ok = RedisStore.upsert(@user_session, @config)
-      assert @exp = get_exp(@key)
-      assert [@key, @exp_str] = list_set_values(@set_key)
-      assert @exp = get_exp(@set_key)
+      assert @exp = get_exp(@exp_oset_key)
+      assert @exp = get_exp(@lock_set_key)
+      assert @exp = get_exp(@session_set_key)
     end
 
     test "separates by type" do
       other_type = %{@user_session | type: :oauth2}
       assert :ok = RedisStore.upsert(@user_session, @config)
       assert :ok = RedisStore.upsert(other_type, @config)
-      assert session = get(@key)
-      assert oauth2_session = get(session_key(@sid, @uid, :oauth2))
+      assert session = get_session_set(@sid)
+      assert oauth2_session = get_hash_set(session_set_key(@uid, :oauth2), @sid)
       assert oauth2_session != session
-
-      assert [@key, @exp_str] == list_set_values(@set_key)
-
-      assert [session_key(@sid, @uid, :oauth2), @exp_str] ==
-               list_set_values(user_sessions_key(@uid, :oauth2))
     end
 
-    test "updates existing session, ttl, exp" do
+    test "updates existing session and set expirations" do
       assert :ok = RedisStore.upsert(@user_session, @config)
-      assert @exp = get_exp(@key)
 
       new_exp = @exp + 10
 
@@ -129,128 +142,76 @@ defmodule Charon.SessionStore.RedisStoreTest do
                |> Map.merge(%{extra_payload: %{new: "key"}, refresh_expires_at: new_exp})
                |> RedisStore.upsert(@config)
 
-      assert "signed." <> <<_::256>> <> "." <> new_session = get(@key)
+      assert "signed." <> <<_::256>> <> "." <> new_session = get_session_set(@sid)
 
-      assert ^new_exp = get_exp(@key)
-      assert [@key, to_string(new_exp)] == list_set_values(@set_key)
+      assert new_exp == get_exp(@exp_oset_key)
+      assert new_exp == get_exp(@lock_set_key)
+      assert new_exp == get_exp(@session_set_key)
+      assert [@sid, to_string(new_exp)] == list_oset_values(@exp_oset_key)
 
       assert %{extra_payload: %{new: "key"}} = new_session |> :erlang.binary_to_term()
     end
 
+    test "does not reduce set expirations" do
+      assert :ok = RedisStore.upsert(@user_session, @config)
+
+      far_future = @now + 10000
+      set_exp(@exp_oset_key, far_future)
+      set_exp(@lock_set_key, far_future)
+      set_exp(@session_set_key, far_future)
+
+      assert :ok = RedisStore.upsert(%{@user_session | id: "b"}, @config)
+
+      assert far_future == get_exp(@exp_oset_key)
+      assert far_future == get_exp(@lock_set_key)
+      assert far_future == get_exp(@session_set_key)
+    end
+
     test "prunes expired sessions" do
       # unexpired, present
-      add_to_set(@set_key, @exp, "a")
-      # expired, somehow present
-      add_to_set(@set_key, 0, "c")
+      add_to_oset(@exp_oset_key, @exp, "a")
+      # expired, present
+      add_to_oset(@exp_oset_key, 0, "c")
+      add_to_hash_set(@lock_set_key, "c", "12")
+
+      add_session_set(
+        "c",
+        %{@user_session | id: "c", refresh_expires_at: @now - 5} |> serialize() |> sign()
+      )
 
       assert :ok = RedisStore.upsert(@user_session, @config)
 
-      keys = list_set_values(@set_key)
-      assert @key in keys
-      assert "a" in keys
-      assert "c" not in keys
+      assert "c" not in list_oset_values(@exp_oset_key)
+      assert "c" not in list_hset_values(@session_set_key)
+      assert "c" not in list_hset_values(@lock_set_key)
     end
 
-    test "updates user's sessions set ttl" do
-      add_to_set(@set_key, @exp, "a")
-      set_exp(@set_key, @exp)
+    test "only prunes once per hour" do
+      assert :ok = RedisStore.upsert(@user_session, @config)
 
-      assert @exp == get_exp(@set_key)
+      # expired, present
+      add_to_oset(@exp_oset_key, 0, "c")
+      add_to_hash_set(@lock_set_key, "c", "12")
 
-      new_exp = @exp + 10
-      :ok = RedisStore.upsert(%{@user_session | refresh_expires_at: new_exp}, @config)
+      assert :ok = RedisStore.upsert(@lock_incr_user_session, @config)
 
-      assert new_exp == get_exp(@set_key)
+      assert "c" in list_oset_values(@exp_oset_key)
+      assert "c" in list_hset_values(@lock_set_key)
     end
 
-    test "prunes expired sessions on upsert of session with reduced refresh exp" do
-      # unexpired, present
-      add_to_set(@set_key, @exp, "a")
-      # expired, somehow present
-      add_to_set(@set_key, 0, "c")
-
-      assert :ok = RedisStore.upsert(%{@user_session | expires_at: @exp}, @config)
-
-      keys = list_set_values(@set_key)
-      assert @key in keys
-      assert "a" in keys
-      assert "c" not in keys
-    end
-
-    test "user's session set ttl correct after reduced but highest refresh exp session upsert" do
-      add_to_set(@set_key, @exp, "a")
-      set_exp(@set_key, @exp)
-
-      new_exp = @exp + 10
-
-      :ok =
-        %{@user_session | expires_at: new_exp, refresh_expires_at: new_exp}
-        |> RedisStore.upsert(@config)
-
-      assert new_exp == get_exp(@set_key)
-    end
-
-    test "user's session set ttl correct after reduced and NOT highest refresh exp session upsert" do
-      higher_exp = @exp + 10
-      add_to_set(@set_key, higher_exp, "a")
-      set_exp(@set_key, higher_exp)
-
-      assert :ok =
-               %{@user_session | expires_at: @exp, refresh_expires_at: @exp}
-               |> RedisStore.upsert(@config)
-
-      assert higher_exp == get_exp(@set_key)
-    end
-
-    test "user's session set ttl correct after reduced first-for-user session upsert" do
-      assert :ok =
-               %{@user_session | expires_at: @exp, refresh_expires_at: @exp}
-               |> RedisStore.upsert(@config)
-
-      assert @exp == get_exp(@set_key)
-    end
-
-    test "can handle negative session ttl" do
-      :ok =
-        @user_session
-        |> Map.put(:refresh_expires_at, @exp - 500)
-        |> RedisStore.upsert(@config)
-
-      refute get(@key)
-      refute get(@set_key)
+    test "skips already-expired session" do
+      session = %{@user_session | refreshed_at: @now + 10000}
+      assert :ok = RedisStore.upsert(session, @config)
+      assert {:ok, []} = command(~w(KEYS *))
     end
 
     test "implements optimistic locking with respect to input session" do
       assert :ok = RedisStore.upsert(@user_session, @config)
       # stored lock_version has been increased
       assert {:error, :conflict} = RedisStore.upsert(@user_session, @config)
-    end
-
-    test "optimistic locking works for conflicts during upsert itself" do
-      assert :ok = RedisStore.upsert(@user_session, @config)
-
-      with_mock RedisClient,
-                [:passthrough],
-                conn_pipeline: fn
-                  commands = [["WATCH", _, _], _], conn, _ ->
-                    # mess with the transaction by modifying the session from another Redis client
-                    # in between the WATCH command and the rest of the operation
-                    conn
-                    |> Redix.pipeline(commands)
-                    |> tap(fn _ ->
-                      ConnectionPool.checkout() |> Redix.command(["SET", @key, "other"])
-                    end)
-
-                  # actually execute everything else
-                  commands, conn, _debug? ->
-                    Redix.pipeline(conn, commands)
-                end do
-        # this upsert is cancelled
-        assert {:error, :conflict} = RedisStore.upsert(@lock_incr_user_session, @config)
-      end
-
-      # the other "upsert" has won
-      assert "other" == get(@key)
+      assert @lock_incr_user_session |> serialize() |> sign() == get_session_set(@sid)
+      assert "1" == get_lock_set(@sid)
+      assert [@sid, @exp_str] == list_oset_values(@exp_oset_key)
     end
   end
 
@@ -259,120 +220,120 @@ defmodule Charon.SessionStore.RedisStoreTest do
       assert :ok = RedisStore.delete(@sid, @uid, :full, @config)
     end
 
-    test "deletes session" do
+    test "deletes session from all sets" do
       insert(@user_session)
-      assert :ok = RedisStore.delete(@sid, @uid, :full, @config)
-      refute get(@key)
+      insert(%{@user_session | id: "b"})
+
+      assert :ok = RedisStore.delete("b", @uid, :full, @config)
+
+      assert @user_session |> serialize() |> sign() == get_session_set(@sid)
+      assert "0" == get_lock_set(@sid)
+      assert [@sid, @exp_str] == list_oset_values(@exp_oset_key)
     end
 
-    test "also drops the session key in the user's session set" do
-      add_to_set(@set_key, @exp, "a")
-      add_to_set(@set_key, @exp, @key)
-      assert :ok = RedisStore.delete(@sid, @uid, :full, @config)
-      assert ["a", @exp_str] == list_set_values(@set_key)
-    end
+    test "all set exps correct if deleted session was highest exp session" do
+      insert(@user_session)
+      insert(%{@user_session | id: "b", refresh_expires_at: @exp + 10})
+      insert(%{@user_session | id: "c", refresh_expires_at: @exp + 20})
 
-    test "prunes expired sessions from user set" do
-      # unexpired, present
-      add_to_set(@set_key, @exp, @key)
-      # expired, somehow present
-      add_to_set(@set_key, 0, "c")
-
-      assert :ok = RedisStore.delete(@sid, @uid, :full, @config)
-
-      keys = list_set_values(@set_key)
-      refute @key in keys
-      assert "c" not in keys
-    end
-
-    test "user's session set ttl correct if deleted session was highest exp session" do
-      add_to_set(@set_key, @exp, "a")
-      add_to_set(@set_key, @exp + 5, @key)
-      set_exp(@set_key, @exp + 5)
-
-      assert :ok = RedisStore.delete(@sid, @uid, :full, @config)
+      assert :ok = RedisStore.delete("c", @uid, :full, @config)
 
       # exp reduced to next-in-line highest exp session
-      assert @exp == get_exp(@set_key)
+      assert @exp + 10 == get_exp(@exp_oset_key)
+      assert @exp + 10 == get_exp(@lock_set_key)
+      assert @exp + 10 == get_exp(@session_set_key)
     end
 
-    test "user's session set ttl correct(ed) if deleted session not found" do
-      add_to_set(@set_key, @exp, "a")
-      # the set should never have this value, which doesn't match the exp of "a"
-      set_exp(@set_key, @exp + 5)
+    test "all set exps correct(ed) if deleted session not found" do
+      insert(@user_session)
+      # the set should never have this value, which doesn't match the exp of @user_session
+      far_future = @now + 10000
+      set_exp(@exp_oset_key, far_future)
+      set_exp(@lock_set_key, far_future)
+      set_exp(@session_set_key, far_future)
 
-      assert :ok = RedisStore.delete(@sid, @uid, :full, @config)
+      assert :ok = RedisStore.delete("b", @uid, :full, @config)
 
       # exp reduced to next-in-line highest exp session
-      assert @exp == get_exp(@set_key)
+      assert @exp = get_exp(@exp_oset_key)
+      assert @exp = get_exp(@lock_set_key)
+      assert @exp = get_exp(@session_set_key)
     end
 
-    test "user's session set ttl correct if deleted session was NOT highest exp session" do
-      add_to_set(@set_key, @exp + 5, "a")
-      add_to_set(@set_key, @exp, @key)
-      set_exp(@set_key, @exp + 5)
+    test "all set exps correct if deleted session was NOT highest exp session" do
+      insert(@user_session)
+      insert(%{@user_session | id: "b", refresh_expires_at: @exp + 10})
+      insert(%{@user_session | id: "c", refresh_expires_at: @exp + 20})
 
-      assert :ok = RedisStore.delete(@sid, @uid, :full, @config)
+      assert :ok = RedisStore.delete("b", @uid, :full, @config)
 
       # set exp is unchanged
-      assert @exp + 5 == get_exp(@set_key)
+      assert @exp + 20 == get_exp(@exp_oset_key)
+      assert @exp + 20 == get_exp(@lock_set_key)
+      assert @exp + 20 == get_exp(@session_set_key)
     end
 
-    test "user's session set removed if deleted session was last session" do
-      add_to_set(@set_key, @exp, @key)
+    test "all sets removed if deleted session was last session" do
+      insert(@user_session)
       assert :ok = RedisStore.delete(@sid, @uid, :full, @config)
-      refute get(@set_key)
+      assert {:ok, []} = command(~w(KEYS *))
     end
   end
 
   describe "get_all/3" do
+    test "works when no keys" do
+      assert [] == RedisStore.get_all(@uid, :full, @config)
+    end
+
     test "returns the user's unexpired, deserialized sessions of requested type" do
       # unexpired, present
-      add_to_set(@set_key, @exp, "a")
-      insert("a", %{@user_session | id: "a"} |> serialize() |> sign())
-      # unexpired, missing
-      add_to_set(@set_key, @exp, "b")
+      add_session_set(@sid, @user_session |> serialize() |> sign())
+      # unsigned
+      add_session_set("b", %{@user_session | id: "b"} |> serialize())
       # expired, somehow present
-      add_to_set(@set_key, 0, "c")
-      insert("c", %{@user_session | id: "c"} |> serialize() |> sign())
-      # expired and missing as it should be
-      add_to_set(@set_key, 0, "d")
-      # another user's session
-      add_to_set(user_sessions_key(@uid + 1), @exp, "e")
-      insert("e", %{@user_session | id: "e", user_id: @uid + 1} |> serialize() |> sign())
-      # unexpired, present, other type
-      add_to_set(user_sessions_key(@uid, :oauth2), @exp, "f")
-      insert("f", %{@user_session | id: "f", type: :oauth2} |> serialize() |> sign())
+      add_session_set(
+        "c",
+        %{@user_session | id: "c", refresh_expires_at: @now - 5} |> serialize() |> sign()
+      )
 
-      assert [@user_session] == RedisStore.get_all(@uid, :full, @config)
+      # another user's session
+      add_session_set("d", %{@user_session | id: "d", user_id: @uid + 1} |> serialize() |> sign())
+      # wrong type
+      add_session_set("e", %{@user_session | id: "e", type: :wrong} |> serialize() |> sign())
+
+      assert capture_log(fn ->
+               assert [@user_session] == RedisStore.get_all(@uid, :full, @config)
+             end) =~ "Ignored Redis session"
     end
   end
 
   describe "delete_all/3" do
-    test "removes all sessions of requested type and the user's session set" do
-      # unexpired, present
-      add_to_set(@set_key, @exp, "a")
-      insert("a", %{@user_session | id: "a"} |> serialize() |> sign())
-      # unexpired, missing
-      add_to_set(@set_key, @exp, "b")
-      # expired, somehow present
-      add_to_set(@set_key, 0, "c")
-      insert("c", %{@user_session | id: "c"} |> serialize() |> sign())
-      # expired and missing as it should be
-      add_to_set(@set_key, 0, "d")
-      # another user's session
-      other_users_set_key = user_sessions_key(@uid + 1)
-      add_to_set(other_users_set_key, @exp, "e")
-      insert("e", %{@user_session | id: "e", user_id: @uid + 1} |> serialize() |> sign())
-      # unexpired, present, other type
-      oauth2_set_key = user_sessions_key(@uid, :oauth2)
-      add_to_set(oauth2_set_key, @exp, "f")
-      insert("f", %{@user_session | id: "f", type: :oauth2} |> serialize() |> sign())
+    test "works when no keys" do
+      assert :ok == RedisStore.delete_all(@uid, :full, @config)
+      assert {:ok, []} = command(~w(KEYS *))
+    end
+
+    test "works when no sessions" do
+      add_to_oset(@exp_oset_key, @exp, @sid)
+      add_to_hash_set(@lock_set_key, @sid, 12)
+      assert :ok == RedisStore.delete_all(@uid, :full, @config)
+      assert {:ok, []} = command(~w(KEYS *))
+    end
+
+    test "removes all sessions of requested type" do
+      insert(@user_session)
+
+      assert [@exp_oset_key, @lock_set_key, @session_set_key] =
+               command(~w(KEYS *)) |> elem(1) |> Enum.sort()
+
+      insert(%{@user_session | type: :oauth2})
+      insert(%{@user_session | user_id: @uid + 1})
 
       assert :ok == RedisStore.delete_all(@uid, :full, @config)
-      assert {:ok, keys} = command(~w(KEYS *))
 
-      assert [oauth2_set_key, other_users_set_key, "e", "f"] == Enum.sort(keys)
+      keys = command(~w(KEYS *)) |> elem(1) |> Enum.sort()
+      count = Enum.count(keys)
+      assert count == Enum.count(keys -- [@exp_oset_key, @lock_set_key, @session_set_key])
     end
   end
 end

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -1,14 +1,19 @@
 defmodule Charon.TestUtils do
-  alias Charon.SessionStore.RedisStore
+  alias Charon.SessionStore.RedisStore.StoreImpl
 
-  def session_key(session_id, user_id, type \\ :full, prefix \\ "charon_") do
-    RedisStore.session_key(session_id, to_string(user_id), to_string(type), prefix)
+  def session_set_key(user_id, type \\ :full, prefix \\ "charon_") do
+    StoreImpl.session_set_key({to_string(user_id), to_string(type), prefix})
     |> IO.iodata_to_binary()
   end
 
-  # key for the sorted-by-expiration-timestamp set of the user's session keys
-  def user_sessions_key(user_id, type \\ :full, prefix \\ "charon_") do
-    RedisStore.set_key(to_string(user_id), to_string(type), prefix) |> IO.iodata_to_binary()
+  def exp_oset_key(user_id, type \\ :full, prefix \\ "charon_") do
+    StoreImpl.exp_oset_key({to_string(user_id), to_string(type), prefix})
+    |> IO.iodata_to_binary()
+  end
+
+  def lock_set_key(user_id, type \\ :full, prefix \\ "charon_") do
+    StoreImpl.lock_set_key({to_string(user_id), to_string(type), prefix})
+    |> IO.iodata_to_binary()
   end
 
   def conn(), do: Plug.Test.conn(:get, "/")


### PR DESCRIPTION
Session stores LocalStore and RedisStore now implement optimistic locking on the `lock_version` value in the session struct.

The RedisStore has received a complete overhaul with a new storage format based on three sets per user per session type. One set maps session ids to actual sessions, one maps session ids to `lock_version` values, and one is an ordered set of session ids orders by expiration timestamp. Combined with Redis functions (Lua scripting), every RedisStore function now only makes a single round trip to the Redis server. A full refresh would take two (one for get, one for upsert). Additionally, no "SCAN" commands are ever needed, and all keys eventually expire: the set contents are pruned on session upsert, and the sets themselves expire when their last member expires.

This update contains major breaking changes, not only in its requirement of Redis 7.x.x, but also in migrating sessions to the new storage format in Charon v2. ~A v2 PR~ #57  + release is required to provide a migration path without dropping sessions.

Closes #23. Closes #54.