### PR TITLE
Migrate to new v3 storage format

### DIFF
--- a/lib/charon/session_store/redis_store.ex
+++ b/lib/charon/session_store/redis_store.ex
@@ -46,101 +46,109 @@ defmodule Charon.SessionStore.RedisStore do
   @impl true
   def get(session_id, user_id, type, config) do
     mod_conf = get_mod_config(config)
-    {user_id_str, type_str, key_prefix} = key_data(user_id, type, mod_conf)
-    old_session_key = old_session_key(session_id, user_id_str, type_str, key_prefix)
-    session_key = session_key(session_id, user_id_str, type_str, key_prefix)
+    key_data = key_data(user_id, type, mod_conf)
+    session_set_key = session_set_key(key_data)
+    oldest_session_key = oldest_session_key(session_id, key_data)
+    old_session_key = old_session_key(session_id, key_data)
 
-    # TODO: all of this can be replaced by GET single key after a while
-    ["MGET", session_key, old_session_key]
-    |> mod_conf.redix_module.command()
+    [
+      ["HGET", session_set_key, session_id],
+      ["MGET", old_session_key, oldest_session_key]
+    ]
+    |> mod_conf.redix_module.pipeline()
     |> case do
-      {:ok, results} -> Enum.find_value(results, &deserialize(&1, mod_conf, config))
-      error -> error
+      {:ok, [h_result, m_results]} ->
+        Enum.find_value([h_result | m_results], &deserialize(&1, mod_conf, config))
+        |> validate(session_id, user_id, type, Internal.now())
+
+      error ->
+        error
     end
   end
 
   @impl true
+  def upsert(_session = %{refresh_expires_at: exp, refreshed_at: now}, _config) when exp < now,
+    do: :ok
+
   def upsert(
         session = %{
           id: sid,
           user_id: uid,
           type: type,
           refreshed_at: now,
-          expires_at: s_exp,
           refresh_expires_at: exp
         },
         config
       ) do
     mod_conf = get_mod_config(config)
-    {uid_str, type_str, key_prefix} = key_data(uid, type, mod_conf)
-    session_key = session_key(sid, uid_str, type_str, key_prefix)
-    set_key = set_key(uid_str, type_str, key_prefix)
+    key_data = key_data(uid, type, mod_conf)
+    session_set_key = session_set_key(key_data)
+    exp_oset_key = exp_oset_key(key_data)
     exp_str = Integer.to_string(exp)
     now = Integer.to_string(now)
 
-    # upsert the actual session as a separate key-value pair that expires when the refresh token expires
-    upsert_session_c = ["SET", session_key, serialize(session, mod_conf, config), "EXAT", exp_str]
-    # add session key to user's session set, with exp timestamp as score (or update score)
-    upsert_set_c = ["ZADD", set_key, exp_str, session_key]
-    max_exp_c = get_max_exp_session_cmd(set_key)
-    prune_set_c = prune_session_set_cmd(set_key, now)
+    serialized = serialize(session, mod_conf, config)
+    new_upsert_c = ["HSET", session_set_key, sid, serialized]
+    exp_new_upsert_c = ["EXPIRE", session_set_key, to_string(config.refresh_token_ttl)]
+    new_exp_oset_c = ["ZADD", exp_oset_key, exp_str, sid]
+    exp_new_exp_oset_c = ["EXPIRE", exp_oset_key, to_string(config.refresh_token_ttl)]
 
-    if s_exp == exp do
-      # s_exp == exp, we can't assume that this session has the highest refresh exp
-      # because this session's refresh_expires_at is reduced so that it is <= expires_at
+    # cleanup old format sessions on new format upsert
+    oldest_session_key = oldest_session_key(sid, key_data)
+    old_session_key = old_session_key(sid, key_data)
+    old_set_key = old_set_key(key_data)
+    del_old_c = ["DEL", old_session_key, oldest_session_key]
+    del_old_oset_c = ["ZREM", old_set_key, old_session_key, oldest_session_key]
+    prune_old_c = prune_session_set_cmd(old_set_key, now)
 
-      [@multi, max_exp_c, upsert_session_c, upsert_set_c, prune_set_c, @exec]
-      |> mod_conf.redix_module.pipeline()
-      |> case do
-        {:ok, [_, _, _, _, _, [prev_max_exp_session, _, _, _]]} ->
-          # prev_max_exp_session had the highest exp *before* this session was upserted
-          # update user session set ttl if there is no other session OR the new session's exp is the highest
-          {prev_exists?, prev_max_exp_str} = parse_zrange_withscores(prev_max_exp_session)
-          prev_max_exp = String.to_integer(prev_max_exp_str)
-          if not prev_exists? or exp > prev_max_exp, do: put_s_exp(set_key, exp_str, mod_conf)
-          :ok
-
-        error ->
-          redis_result_to_error(error)
-      end
-    else
-      # s_exp != exp; we can assume that this session has the highest refresh exp of all of the user's sessions
-      set_exp_c = put_s_exp_cmd(set_key, exp_str)
-
-      [@multi, upsert_session_c, upsert_set_c, set_exp_c, prune_set_c, @exec]
-      |> mod_conf.redix_module.pipeline()
-      |> case do
-        {:ok, [_, _, _, _, _, [_, _, _, _]]} -> :ok
-        error -> redis_result_to_error(error)
-      end
+    [
+      @multi,
+      new_upsert_c,
+      exp_new_upsert_c,
+      new_exp_oset_c,
+      exp_new_exp_oset_c,
+      del_old_c,
+      del_old_oset_c,
+      prune_old_c,
+      @exec
+    ]
+    |> mod_conf.redix_module.pipeline()
+    |> case do
+      {:ok, [_, _, _, _, _, _, _, _, [_, _, _, _, _, _, _]]} -> :ok
+      error -> redis_result_to_error(error)
     end
+    |> tap(fn _ ->
+      prune_new_sessions(exp_oset_key, session_set_key, now, mod_conf)
+    end)
   end
 
   @impl true
   def delete(session_id, user_id, type, config) do
     mod_conf = get_mod_config(config)
-    {user_id_str, type_str, key_prefix} = key_data(user_id, type, mod_conf)
-    old_session_key = old_session_key(session_id, user_id_str, type_str, key_prefix)
-    session_key = session_key(session_id, user_id_str, type_str, key_prefix)
-    set_key = set_key(user_id_str, type_str, key_prefix)
-    now = Internal.now() |> Integer.to_string()
+    key_data = key_data(user_id, type, mod_conf)
+    oldest_session_key = oldest_session_key(session_id, key_data)
+    old_session_key = old_session_key(session_id, key_data)
+    session_set_key = session_set_key(key_data)
+    exp_oset_key = exp_oset_key(key_data)
+    old_set_key = old_set_key(key_data)
 
-    # TODO: all of this can be replaced by DEL single key after a while
-    delete_c = ["DEL", session_key, old_session_key]
-    delete_key_c = ["ZREM", set_key, session_key, old_session_key]
-    max_exp_c = get_max_exp_session_cmd(set_key)
-    prune_set_c = prune_session_set_cmd(set_key, now)
+    del_c = ["DEL", old_session_key, oldest_session_key]
+    del_old_oset_c = ["ZREM", old_set_key, old_session_key, oldest_session_key]
+    del_oset_c = ["ZREM", exp_oset_key, session_id]
+    del_session_set_c = ["HDEL", session_set_key, session_id]
+    max_exp_c = get_max_exp_session_cmd(old_set_key)
 
-    [@multi, max_exp_c, delete_c, delete_key_c, prune_set_c, max_exp_c, @exec]
+    [@multi, max_exp_c, del_c, del_old_oset_c, del_oset_c, del_session_set_c, max_exp_c, @exec]
     |> mod_conf.redix_module.pipeline()
     |> case do
-      {:ok, [_, _, _, _, _, _, [pre_max_exp_session, _, _, _, post_max_exp_session]]} ->
+      {:ok, [_, _, _, _, _, _, _, [pre_max_exp_session, _, _, _, _, post_max_exp_session]]} ->
         # pre_max_exp_session had the highest exp *before* this session was deleted
         {pre_exists?, pre_max_exp_str} = parse_zrange_withscores(pre_max_exp_session)
         {post_exists?, post_max_exp_str} = parse_zrange_withscores(post_max_exp_session)
 
         if pre_exists? and post_exists? and post_max_exp_str != pre_max_exp_str do
-          put_s_exp(set_key, post_max_exp_str, mod_conf)
+          put_s_exp(old_set_key, post_max_exp_str, mod_conf)
+          put_s_exp(exp_oset_key, post_max_exp_str, mod_conf)
         end
 
         :ok
@@ -153,25 +161,38 @@ defmodule Charon.SessionStore.RedisStore do
   @impl true
   def get_all(user_id, type, config) do
     mod_conf = get_mod_config(config)
-    {user_id_str, type_str, key_prefix} = key_data(user_id, type, mod_conf)
+    key_data = key_data(user_id, type, mod_conf)
+    session_set_key = session_set_key(key_data)
+    now = Internal.now()
 
-    with {:ok, keys = [_ | _]} <-
-           get_valid_session_keys(user_id_str, type_str, key_prefix, mod_conf),
-         {:ok, values} <- mod_conf.redix_module.command(["MGET" | keys]) do
-      values |> Stream.map(&deserialize(&1, mod_conf, config)) |> Enum.reject(&is_nil/1)
-    else
-      {:ok, []} -> []
-      other -> other
+    with {:ok, keys} <- get_valid_session_keys(key_data, mod_conf),
+         {:ok, values} <-
+           [["HVALS", session_set_key]]
+           |> then(fn commands ->
+             case keys do
+               [] -> commands
+               _ -> [["MGET" | keys] | commands]
+             end
+           end)
+           |> mod_conf.redix_module.pipeline() do
+      values
+      |> List.flatten()
+      |> Stream.map(&deserialize(&1, mod_conf, config))
+      |> Stream.map(&validate(&1, user_id, type, now))
+      |> Enum.reject(&is_nil/1)
     end
   end
 
   @impl true
   def delete_all(user_id, type, config) do
     mod_conf = get_mod_config(config)
-    {user_id_str, type_str, key_prefix} = key_data(user_id, type, mod_conf)
+    key_data = key_data(user_id, type, mod_conf)
+    session_set_key = session_set_key(key_data)
+    exp_oset_key = exp_oset_key(key_data)
+    old_set_key = old_set_key(key_data)
 
-    with {:ok, keys} <- get_session_keys(user_id_str, type_str, key_prefix, mod_conf),
-         to_delete = [set_key(user_id_str, type_str, key_prefix) | keys],
+    with {:ok, keys} <- get_session_keys(key_data, mod_conf),
+         to_delete = [old_set_key, session_set_key, exp_oset_key | keys],
          {:ok, _} <- ["DEL" | to_delete] |> mod_conf.redix_module.command() do
       :ok
     else
@@ -280,35 +301,47 @@ defmodule Charon.SessionStore.RedisStore do
   # using the "old" format for :full sessions prevents old sessions from suddenly being logged-out
   # so this code is "backwards compatible" with respect to old sessions being retrievable
   @doc false
-  def old_session_key(session_id, user_id, "full", key_prefix),
+  def oldest_session_key(session_id, {user_id, "full", key_prefix}),
     do: :crypto.hash(:blake2s, [key_prefix, ".s.", user_id, ?., session_id])
 
-  def old_session_key(session_id, user_id, type, key_prefix),
+  def oldest_session_key(session_id, {user_id, type, key_prefix}),
     do: :crypto.hash(:blake2s, [key_prefix, ".s.", user_id, ?., type, ?., session_id])
 
   # session key. The session ID is assumed to be a unique value.
   @doc false
-  def session_key(session_id, user_id, type, key_prefix),
+  def old_session_key(session_id, {user_id, type, key_prefix}),
     do: [key_prefix, ".s.", user_id, ?., type, ?., session_id]
 
   # key for the sorted-by-expiration-timestamp set of the user's session keys
   @doc false
-  def set_key(user_id, "full", key_prefix), do: [key_prefix, ".u.", user_id]
-  def set_key(user_id, type, key_prefix), do: [key_prefix, ".u.", user_id, ?., type]
+  def old_set_key({user_id, "full", key_prefix}), do: [key_prefix, ".u.", user_id]
+  def old_set_key({user_id, type, key_prefix}), do: [key_prefix, ".u.", user_id, ?., type]
+
+  # key for the sorted-by-expiration-timestamp set of the user's session keys
+  @doc false
+  # the expiration ordered set stores sids and expiration timestamps sorted by the timestamp
+  def exp_oset_key({uid, type, prefix}), do: to_key(uid, type, prefix, "e")
+
+  @doc false
+  # the session set maps sid's to sessions
+  def session_set_key({uid, type, prefix}), do: to_key(uid, type, prefix, "se")
+
+  # create a key from a user_id, sessions type, prefix, and separator
+  defp to_key(uid, type, prefix, sep), do: [prefix, ?., sep, ?., uid, ?., type]
 
   # get all keys, including expired ones, for a user
-  defp get_session_keys(user_id, type, key_prefix, config) do
+  defp get_session_keys(key_data, config) do
     # get all of the user's session keys (index 0 = first, -1 = last)
-    ["ZRANGE", set_key(user_id, type, key_prefix), "0", "-1"]
+    ["ZRANGE", old_set_key(key_data), "0", "-1"]
     |> config.redix_module.command()
   end
 
   # get all valid keys for a user
-  defp get_valid_session_keys(user_id, type, key_prefix, config) do
+  defp get_valid_session_keys(key_data, config) do
     now = Internal.now() |> Integer.to_string()
 
     # get all of the user's valid session keys (with score/timestamp >= now)
-    ["ZRANGE", set_key(user_id, type, key_prefix), now, "+inf", "BYSCORE"]
+    ["ZRANGE", old_set_key(key_data), now, "+inf", "BYSCORE"]
     |> config.redix_module.command()
   end
 
@@ -318,7 +351,8 @@ defmodule Charon.SessionStore.RedisStore do
   defp parse_zrange_withscores(_), do: {false, "0"}
 
   # clean up the user's old sessions
-  defp prune_session_set_cmd(set_key, now_str), do: ["ZREMRANGEBYSCORE", set_key, "-inf", now_str]
+  defp prune_session_set_cmd(set_key, now_str),
+    do: ["ZREMRANGEBYSCORE", set_key, "-inf", now_str]
 
   # grab the session key and score (= exp timestamp) of the highest-exp session of the user
   defp get_max_exp_session_cmd(set_key) do
@@ -348,5 +382,36 @@ defmodule Charon.SessionStore.RedisStore do
     |> then(fn {:ok, [new_cursor | [partial_results]]} ->
       find_session_sets(config, mod_conf, set_keys ++ partial_results, new_cursor)
     end)
+  end
+
+  defp prune_new_sessions(exp_oset_key, session_set_key, now, mod_conf) do
+    with {:ok, expired = [_ | _]} <-
+           mod_conf.redix_module.command(["ZRANGE", exp_oset_key, "-inf", "(#{now}", "BYSCORE"]),
+         {:ok, _} <-
+           mod_conf.redix_module.pipeline([
+             ["ZREM", exp_oset_key, expired],
+             ["HDEL", session_set_key, expired]
+           ]) do
+      :ok
+    else
+      {:ok, []} -> :ok
+      other -> Logger.error(inspect(other))
+    end
+  end
+
+  # validate that session matches uid, type and is not expired
+  defp validate(session, uid, type, now) do
+    case session do
+      s = %{refresh_expires_at: exp, user_id: ^uid, type: ^type} when exp >= now -> s
+      _ -> nil
+    end
+  end
+
+  # validate that session matches sid, uid, type and is not expired
+  defp validate(session, sid, uid, type, now) do
+    case validate(session, uid, type, now) do
+      s = %{id: ^sid} -> s
+      _ -> nil
+    end
   end
 end

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -1,14 +1,24 @@
 defmodule Charon.TestUtils do
   alias Charon.SessionStore.RedisStore
 
-  def session_key(session_id, user_id, type \\ :full, prefix \\ "charon_") do
-    RedisStore.session_key(session_id, to_string(user_id), to_string(type), prefix)
+  def session_set_key(user_id, type \\ :full, prefix \\ "charon_") do
+    RedisStore.session_set_key({to_string(user_id), to_string(type), prefix})
+    |> IO.iodata_to_binary()
+  end
+
+  def exp_oset_key(user_id, type \\ :full, prefix \\ "charon_") do
+    RedisStore.exp_oset_key({to_string(user_id), to_string(type), prefix})
+    |> IO.iodata_to_binary()
+  end
+
+  def old_session_key(session_id, user_id, type \\ :full, prefix \\ "charon_") do
+    RedisStore.old_session_key(session_id, {to_string(user_id), to_string(type), prefix})
     |> IO.iodata_to_binary()
   end
 
   # key for the sorted-by-expiration-timestamp set of the user's session keys
-  def user_sessions_key(user_id, type \\ :full, prefix \\ "charon_") do
-    RedisStore.set_key(to_string(user_id), to_string(type), prefix) |> IO.iodata_to_binary()
+  def old_exp_oset_key(user_id, type \\ :full, prefix \\ "charon_") do
+    RedisStore.old_set_key({to_string(user_id), to_string(type), prefix}) |> IO.iodata_to_binary()
   end
 
   def conn(), do: Plug.Test.conn(:get, "/")


### PR DESCRIPTION
Prepares #56. In order to migrate to the new hashset-based storage format, the store upserts in the new format, gets in all formats with precedence given to the newest one, and deletes all formats. Additionally, upsert deletes old storage formats so that each session is always stored in a single format only. Additionally, `migrate_sessions/1` can be used to get it over with, preparing for a v3 deployment.

