### PR TITLE
fix localstore upsert on expired session

### DIFF
--- a/lib/charon/internal/crypto.ex
+++ b/lib/charon/internal/crypto.ex
@@ -201,28 +201,4 @@ defmodule Charon.Internal.Crypto do
 
   defp verify(data, key, hmac),
     do: if(hmac_matches?(data, key, hmac), do: {:ok, data}, else: {:error, :invalid_signature})
-
-  def random_digits(1) do
-    random_digit()
-  end
-
-  def random_digits(n) do
-    random_digit() + random_digits(n - 1) * 10
-  end
-
-  def random_digit() do
-    case :crypto.strong_rand_bytes(1) |> :binary.decode_unsigned() do
-      0 -> 0
-      1 -> 1
-      2 -> 2
-      3 -> 3
-      4 -> 4
-      5 -> 5
-      6 -> 6
-      7 -> 7
-      8 -> 8
-      9 -> 9
-      _ -> random_digit()
-    end
-  end
 end

--- a/lib/charon/internal/crypto.ex
+++ b/lib/charon/internal/crypto.ex
@@ -201,4 +201,28 @@ defmodule Charon.Internal.Crypto do
 
   defp verify(data, key, hmac),
     do: if(hmac_matches?(data, key, hmac), do: {:ok, data}, else: {:error, :invalid_signature})
+
+  def random_digits(1) do
+    random_digit()
+  end
+
+  def random_digits(n) do
+    random_digit() + random_digits(n - 1) * 10
+  end
+
+  def random_digit() do
+    case :crypto.strong_rand_bytes(1) |> :binary.decode_unsigned() do
+      0 -> 0
+      1 -> 1
+      2 -> 2
+      3 -> 3
+      4 -> 4
+      5 -> 5
+      6 -> 6
+      7 -> 7
+      8 -> 8
+      9 -> 9
+      _ -> random_digit()
+    end
+  end
 end

--- a/test/charon/session_store/local_store_test.exs
+++ b/test/charon/session_store/local_store_test.exs
@@ -64,9 +64,15 @@ defmodule Charon.SessionStore.LocalStoreTest do
       assert :ok = LocalStore.upsert(@user_session, @config)
       current_session = @lock_incr_user_session
       assert {1, %{@user_key => current_session}} == Agent.get(LocalStore, & &1)
-      updated_user_sessioin = %{current_session | refresh_expires_at: @exp + 1}
-      assert :ok = LocalStore.upsert(updated_user_sessioin, @config)
-      assert {2, %{@user_key => incr_lock(updated_user_sessioin)}} == Agent.get(LocalStore, & &1)
+      updated_user_session = %{current_session | refresh_expires_at: @exp + 1}
+      assert :ok = LocalStore.upsert(updated_user_session, @config)
+      assert {2, %{@user_key => incr_lock(updated_user_session)}} == Agent.get(LocalStore, & &1)
+    end
+
+    test "creates new session when old one is expired" do
+      assert :ok = LocalStore.upsert(%{@user_session | refresh_expires_at: now() - 10}, @config)
+      assert :ok = LocalStore.upsert(@user_session, @config)
+      assert {1, %{@user_key => incr_lock(@user_session)}} == Agent.get(LocalStore, & &1)
     end
 
     test "cleans up expired sessions when session count is multiple of 1000" do


### PR DESCRIPTION
`LocalStore.upsert/2` doesn't check whether the given session is expired. It'll update an expired session and expects the new session's lock version to match the expired one's. `LocalStore.get/3` on an expired session returns `nil`, giving no way to check the current lock version. This PR adds a check to `LocalStore.upsert/2` for expired sessions, upserting one doesn't validate the lock version.