### PR TITLE
Allow poly1305 nonce to be generated by configurable function

### DIFF
--- a/lib/charon/token_factory/jwt/config.ex
+++ b/lib/charon/token_factory/jwt/config.ex
@@ -6,11 +6,13 @@ defmodule Charon.TokenFactory.Jwt.Config do
 
   @enforce_keys []
   defstruct get_keyset: &Jwt.default_keyset/1,
-            signing_key: "default"
+            signing_key: "default",
+            gen_poly1305_nonce: :random
 
   @type t :: %__MODULE__{
           get_keyset: (Charon.Config.t() -> Jwt.keyset()),
-          signing_key: binary
+          signing_key: binary,
+          gen_poly1305_nonce: :random | (-> <<_::96>>)
         }
 
   @doc """


### PR DESCRIPTION
This is needed to generate nonces by other mechanisms, like a counter / `NoNoncense`.