### PR TITLE
Fix 1.18 compiler type warning when Blake3 not loaded

### DIFF
--- a/lib/charon/token_factory/jwt/blake3.ex
+++ b/lib/charon/token_factory/jwt/blake3.ex
@@ -3,9 +3,4 @@ if Code.ensure_loaded?(Blake3) do
     @moduledoc false
     def keyed_hash(key, data), do: Blake3.keyed_hash(key, IO.iodata_to_binary(data))
   end
-else
-  defmodule Charon.TokenFactory.Jwt.Blake3 do
-    @moduledoc false
-    def keyed_hash(_key, _data), do: raise("optional dependency :blake3 not loaded")
-  end
 end


### PR DESCRIPTION
```
==> charon
     warning: incompatible types given to Charon.Internal.Crypto.constant_time_compare/2:

         Charon.Internal.Crypto.constant_time_compare(
           Charon.TokenFactory.Jwt.Blake3.keyed_hash(key, data),
           sig
         )

     given types:

         none(), dynamic()

     the 1st argument is empty (often represented as none()), most likely because it is the result of an expression that always fails, such as a `raise` or a previous invalid call. This causes any function called with this value to fail

     where "data" was given the type:

         # type: dynamic()
         # from: lib/charon/token_factory/jwt.ex:270:18
         data

     where "key" was given the type:

         # type: dynamic()
         # from: lib/charon/token_factory/jwt.ex
         {:blake3_256, key}

     where "sig" was given the type:

         # type: dynamic()
         # from: lib/charon/token_factory/jwt.ex:270:44
         sig

     typing violation found at:
     │
 271 │     do: __MODULE__.Blake3.keyed_hash(key, data) |> constant_time_compare(sig)
     │                                                    ~
     │
     └─ (charon 0.0.0+development) lib/charon/token_factory/jwt.ex:271:52: Charon.TokenFactory.Jwt.do_verify/3
```