### PR TITLE
Token signature verification caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.4.0 (pending)
+
+- Add optional `Charon.TokenPlugs.verify_token_signature/2` signature caching
+- Add `Charon.TokenPlugs.SigVerifyCache`, `Charon.TokenPlugs.SigVerifyCache.Behaviour`, `Charon.TokenPlugs.SigVerifyCache.EtsCache` and `Charon.TokenPlugs.SigVerifyCache.RedisCache`
+
 ## 4.3.0
 
 - Improve `Charon.TokenFactory.Jwt` key/header caching and reduce complexity.

--- a/lib/charon/config.ex
+++ b/lib/charon/config.ex
@@ -50,6 +50,7 @@ defmodule Charon.Config do
    - `:session_ttl` Time in seconds until a new session expires OR `:infinite` for non-expiring sessions.
    - `:token_factory_module` A module that implements `Charon.TokenFactory.Behaviour`, used to create and verify authentication tokens.
    - `:token_issuer` Value of the "iss" claim in tokens, for example "https://myapp.com"
+   - `:token_signature_cache_module` A module that implements `Charon.TokenPlugs.SigVerifyCache.Behaviour`, used by `Charon.TokenPlugs.verify_token_signature/2` to cache signature verification results. Defaults to `nil` (caching disabled).
   """
   @enforce_keys [:token_issuer, :get_base_secret]
   defstruct [
@@ -75,7 +76,8 @@ defmodule Charon.Config do
     session_store_module: Charon.SessionStore.RedisStore,
     # 1 year
     session_ttl: 365 * 24 * 60 * 60,
-    token_factory_module: Charon.TokenFactory.Jwt
+    token_factory_module: Charon.TokenFactory.Jwt,
+    token_signature_cache_module: nil
   ]
 
   @type t :: %__MODULE__{
@@ -93,7 +95,8 @@ defmodule Charon.Config do
           session_store_module: module(),
           session_ttl: pos_integer() | :infinite,
           token_factory_module: module(),
-          token_issuer: String.t()
+          token_issuer: String.t(),
+          token_signature_cache_module: module() | nil
         }
 
   @doc """

--- a/lib/charon/token_factory/jwt.ex
+++ b/lib/charon/token_factory/jwt.ex
@@ -80,7 +80,7 @@ defmodule Charon.TokenFactory.Jwt do
         ...,
         optional_modules: %{
           Charon.TokenFactory.Jwt => %{
-            get_keyset: fn -> %{"key1" => {:hmac_sha256, "my_key"}} end,
+            get_keyset: fn _ -> %{"key1" => {:hmac_sha256, "my_key"}} end,
             signing_key: "key1"
           }
         }
@@ -248,8 +248,8 @@ defmodule Charon.TokenFactory.Jwt do
 
   defp maybe_fast_verify({:poly1305, exp_htail, secret, keyset}, token, config) do
     case token do
-      <<@p1305_h, nonce_seg::binary-24, @p1305_kid_seg, ^exp_htail::bits, ?.,
-        enc_pl_and_sig::bits>> ->
+      <<@p1305_h, nonce_seg::binary-24, @p1305_kid_seg, ^exp_htail::binary, ?.,
+        enc_pl_and_sig::binary>> ->
         [@p1305_h, nonce_seg, @p1305_kid_seg, exp_htail]
         |> fast_p1305_verify(nonce_seg, enc_pl_and_sig, secret, config)
 

--- a/lib/charon/token_plugs.ex
+++ b/lib/charon/token_plugs.ex
@@ -198,7 +198,8 @@ defmodule Charon.TokenPlugs do
   That's why caching is disabled by default and should only be enabled for asymmetrically signed tokens.
 
   Claim verification plugs such as `verify_token_exp_claim/2` and `verify_token_fresh/2` are
-  **not** covered by the cache and still run on every request.
+  **not** covered by the cache. They will, and should, still run on every request.
+  This way, deciding if the token has expired is decoupled from the caching of cryptographic operations.
 
   To enable caching, configure a module implementing `Charon.TokenPlugs.SigVerifyCache.Behaviour`
   and configure Charon to use it.

--- a/lib/charon/token_plugs.ex
+++ b/lib/charon/token_plugs.ex
@@ -63,6 +63,7 @@ defmodule Charon.TokenPlugs do
   import Conn, except: [put_private: 3]
 
   alias Charon.{Config, TokenFactory, Internal, SessionStore}
+  alias Charon.TokenPlugs.SigVerifyCache
   use Internal.Constants
   import Internal
   import Charon.Utils
@@ -184,20 +185,57 @@ defmodule Charon.TokenPlugs do
 
   If verification succeeds, the token payload is stored in the connection's private state.
   If verification fails, an authentication error is set instead.
+
+  ## Caching
+
+  When `:token_signature_cache_module` is set in `Charon.Config`, the verification result -
+  both success and failure - is cached by a SHA-256 hash of the token.
+  On a cache hit, cryptographic signature verification is skipped entirely.
+
+  Note that caching is likely to negatively impact performance and memory consumption  for
+  symmetrically signed tokens (HMAC, Poly1305 etc), because they can be verified extremely quickly and efficiently.
+  Asymmetric signing algorithms (RSA, ECDSA, EdDSA etc) are much more expensive in terms of CPU usage.
+  That's why caching is disabled by default and should only be enabled for asymmetrically signed tokens.
+
+  Claim verification plugs such as `verify_token_exp_claim/2` and `verify_token_fresh/2` are
+  **not** covered by the cache and still run on every request.
+
+  To enable caching, configure a module implementing `Charon.TokenPlugs.SigVerifyCache.Behaviour`
+  and configure Charon to use it.
+
+      # config
+      config :my_app, :charon,
+        token_signature_cache_module: Charon.TokenPlugs.SigVerifyCache.EtsCache
   """
   @spec verify_token_signature(Conn.t(), Config.t()) :: Conn.t()
   def verify_token_signature(conn, _charon_config) when is_map_key(conn.private, @auth_error),
     do: conn
 
   def verify_token_signature(conn = %{private: %{@bearer_token => token}}, config) do
-    with {:ok, payload} <- TokenFactory.verify(token, config) do
-      put_private(conn, %{@now => now(), @bearer_token_payload => payload})
+    with now = now(),
+         {:ok, payload} <- maybe_cached_verify(token, now, config) do
+      put_private(conn, %{@now => now, @bearer_token_payload => payload})
     else
       _ -> set_auth_error(conn, "bearer token signature invalid")
     end
   end
 
   def verify_token_signature(conn, _), do: set_auth_error(conn, "bearer token not found")
+
+  defp maybe_cached_verify(token, _now, config = %{token_signature_cache_module: nil}) do
+    TokenFactory.verify(token, config)
+  end
+
+  defp maybe_cached_verify(token, now, config) do
+    with token_hash = :crypto.hash(:sha256, token),
+         :miss <- SigVerifyCache.get(token_hash, config) do
+      verify_res = TokenFactory.verify(token, config)
+      SigVerifyCache.put(token_hash, verify_res, now + config.access_token_ttl, config)
+      verify_res
+    else
+      {_hit, cached_result} -> cached_result
+    end
+  end
 
   @doc """
   Verify that the bearer token payload contains a valid `nbf` (not before) claim.

--- a/lib/charon/token_plugs.ex
+++ b/lib/charon/token_plugs.ex
@@ -192,7 +192,7 @@ defmodule Charon.TokenPlugs do
   both success and failure - is cached by a SHA-256 hash of the token.
   On a cache hit, cryptographic signature verification is skipped entirely.
 
-  Note that caching is likely to negatively impact performance and memory consumption  for
+  Note that caching is likely to negatively impact performance and memory consumption for
   symmetrically signed tokens (HMAC, Poly1305 etc), because they can be verified extremely quickly and efficiently.
   Asymmetric signing algorithms (RSA, ECDSA, EdDSA etc) are much more expensive in terms of CPU usage.
   That's why caching is disabled by default and should only be enabled for asymmetrically signed tokens.

--- a/lib/charon/token_plugs/sig_verify_cache.ex
+++ b/lib/charon/token_plugs/sig_verify_cache.ex
@@ -1,5 +1,5 @@
 defmodule Charon.TokenPlugs.SigVerifyCache do
-  @moduledoc since: "4.2.0"
+  @moduledoc since: "4.4.0"
   @moduledoc """
   Entrypoint for `Charon.TokenPlugs.SigVerifyCache.Behaviour` implementation.
   All functions delegate to the module configured as `:token_signature_cache_module` in

--- a/lib/charon/token_plugs/sig_verify_cache.ex
+++ b/lib/charon/token_plugs/sig_verify_cache.ex
@@ -1,0 +1,18 @@
+defmodule Charon.TokenPlugs.SigVerifyCache do
+  @moduledoc since: "4.2.0"
+  @moduledoc """
+  Entrypoint for `Charon.TokenPlugs.SigVerifyCache.Behaviour` implementation.
+  All functions delegate to the module configured as `:token_signature_cache_module` in
+  `Charon.Config`.
+
+  When `:token_signature_cache_module` is `nil`, caching is disabled entirely.
+  """
+  @behaviour __MODULE__.Behaviour
+
+  @impl true
+  def get(token_hash, config), do: config.token_signature_cache_module.get(token_hash, config)
+
+  @impl true
+  def put(token_hash, value, exp, config),
+    do: config.token_signature_cache_module.put(token_hash, value, exp, config)
+end

--- a/lib/charon/token_plugs/sig_verify_cache/behaviour.ex
+++ b/lib/charon/token_plugs/sig_verify_cache/behaviour.ex
@@ -1,0 +1,33 @@
+defmodule Charon.TokenPlugs.SigVerifyCache.Behaviour do
+  @moduledoc since: "4.2.0"
+  @moduledoc """
+  Behaviour for token signature cache backends used by
+  `Charon.TokenPlugs.verify_token_signature/2`.
+
+  Implementations must provide two functions:
+
+    - `get/2` — look up a cached verification result by token hash
+    - `put/4` — store a verification result with an expiry timestamp
+
+  The default implementation is `Charon.TokenPlugs.SigVerifyCache.EtsCache`, an ETS-based
+  local cache. For multi-node deployments you may supply a custom module that
+  delegates to a shared store such as Redis.
+  """
+  alias Charon.Config
+
+  @doc """
+  Look up a cached verification result by the token's SHA-256 hash binary.
+
+  Returns `{:hit, value}` if a live entry exists, or `:miss` otherwise.
+  """
+  @callback get(token_hash :: binary(), config :: Config.t()) :: {:hit, any()} | :miss
+
+  @doc """
+  Store a verification result keyed by the token's SHA-256 hash binary.
+
+  `exp` is the Unix timestamp (in seconds) at which the entry should be
+  considered stale.
+  """
+  @callback put(token_hash :: binary(), value :: any(), exp :: integer(), config :: Config.t()) ::
+              :ok
+end

--- a/lib/charon/token_plugs/sig_verify_cache/behaviour.ex
+++ b/lib/charon/token_plugs/sig_verify_cache/behaviour.ex
@@ -1,5 +1,5 @@
 defmodule Charon.TokenPlugs.SigVerifyCache.Behaviour do
-  @moduledoc since: "4.2.0"
+  @moduledoc since: "4.4.0"
   @moduledoc """
   Behaviour for token signature cache backends used by
   `Charon.TokenPlugs.verify_token_signature/2`.

--- a/lib/charon/token_plugs/sig_verify_cache/ets_cache.ex
+++ b/lib/charon/token_plugs/sig_verify_cache/ets_cache.ex
@@ -1,5 +1,5 @@
 defmodule Charon.TokenPlugs.SigVerifyCache.EtsCache do
-  @moduledoc since: "4.2.0"
+  @moduledoc since: "4.4.0"
   @moduledoc """
   ETS-based implementation of `Charon.TokenPlugs.SigVerifyCache.Behaviour`.
 

--- a/lib/charon/token_plugs/sig_verify_cache/ets_cache.ex
+++ b/lib/charon/token_plugs/sig_verify_cache/ets_cache.ex
@@ -1,0 +1,90 @@
+defmodule Charon.TokenPlugs.SigVerifyCache.EtsCache do
+  @moduledoc since: "4.2.0"
+  @moduledoc """
+  ETS-based implementation of `Charon.TokenPlugs.SigVerifyCache.Behaviour`.
+
+  When used together with `Charon.TokenPlugs.verify_token_signature/2`,
+  this cache stores the full verification result (success or failure) keyed by a SHA-256
+  hash of the token. Subsequent requests with the same token skip the cryptographic
+  signature verification entirely. This is especially beneficial for EdDSA tokens,
+  where signature verification is expensive.
+
+  Claim verification plugs such as `:verify_token_exp_claim` and `:verify_token_fresh`
+  are **not** covered by the caching mechanism and still run on every request.
+
+  ## Usage
+
+  Add this cache to your supervision tree before using `verify_token_signature/2`:
+
+      children = [
+        Charon.TokenPlugs.SigVerifyCache.EtsCache
+      ]
+
+  ## Options
+
+    - `:cleanup_interval` - interval in milliseconds between expired-entry cleanup passes
+      (default: `60_000`)
+
+  """
+
+  @behaviour Charon.TokenPlugs.SigVerifyCache.Behaviour
+
+  use GenServer
+
+  @table __MODULE__
+  @default_cleanup_interval 60_000
+
+  @doc false
+  def start_link(opts \\ []) do
+    cleanup_interval = Keyword.get(opts, :cleanup_interval, @default_cleanup_interval)
+    GenServer.start_link(__MODULE__, %{cleanup_interval: cleanup_interval}, name: __MODULE__)
+  end
+
+  @doc """
+  Look up a cached verification result by the token's SHA-256 hash binary.
+
+  Returns `{:hit, value}` if a non-expired entry is found, or `:miss` otherwise.
+  """
+  @impl true
+  @spec get(binary(), Charon.Config.t()) :: {:hit, any()} | :miss
+  def get(token_hash, _config) do
+    now = System.os_time(:second)
+
+    case :ets.lookup(@table, token_hash) do
+      [{^token_hash, payload, exp}] when exp > now -> {:hit, payload}
+      _ -> :miss
+    end
+  end
+
+  @doc """
+  Store a verification result in the cache, keyed by the token's SHA-256 hash binary.
+
+  `exp` is the Unix timestamp (in seconds) at which the cache entry should be
+  considered stale.
+  """
+  @impl true
+  @spec put(binary(), any(), integer(), Charon.Config.t()) :: :ok
+  def put(token_hash, payload, exp, _config) do
+    :ets.insert(@table, {token_hash, payload, exp})
+    :ok
+  end
+
+  ## GenServer callbacks
+
+  @impl true
+  def init(%{cleanup_interval: cleanup_interval}) do
+    :ets.new(@table, [:named_table, :public, :set, read_concurrency: true])
+    schedule_cleanup(cleanup_interval)
+    {:ok, %{cleanup_interval: cleanup_interval}}
+  end
+
+  @impl true
+  def handle_info(:cleanup, state = %{cleanup_interval: cleanup_interval}) do
+    now = System.os_time(:second)
+    :ets.select_delete(@table, [{{:_, :_, :"$1"}, [{:"=<", :"$1", now}], [true]}])
+    schedule_cleanup(cleanup_interval)
+    {:noreply, state}
+  end
+
+  defp schedule_cleanup(interval), do: Process.send_after(self(), :cleanup, interval)
+end

--- a/lib/charon/token_plugs/sig_verify_cache/redis_cache.ex
+++ b/lib/charon/token_plugs/sig_verify_cache/redis_cache.ex
@@ -1,6 +1,6 @@
 if Code.ensure_loaded?(Redix) and Code.ensure_loaded?(:poolboy) do
   defmodule Charon.TokenPlugs.SigVerifyCache.RedisCache do
-    @moduledoc since: "4.2.0"
+    @moduledoc since: "4.4.0"
     @moduledoc """
     Redis-based implementation of `Charon.TokenPlugs.SigVerifyCache.Behaviour`.
 

--- a/lib/charon/token_plugs/sig_verify_cache/redis_cache.ex
+++ b/lib/charon/token_plugs/sig_verify_cache/redis_cache.ex
@@ -1,0 +1,48 @@
+if Code.ensure_loaded?(Redix) and Code.ensure_loaded?(:poolboy) do
+  defmodule Charon.TokenPlugs.SigVerifyCache.RedisCache do
+    @moduledoc since: "4.2.0"
+    @moduledoc """
+    Redis-based implementation of `Charon.TokenPlugs.SigVerifyCache.Behaviour`.
+
+    Unlike `Charon.TokenPlugs.SigVerifyCache.EtsCache`, this cache is shared across all
+    nodes that connect to the same Redis instance, making it suitable for multi-node
+    deployments.
+
+    Requires `Charon.SessionStore.RedisStore.ConnectionPool` to be running in your
+    supervision tree (already the case when `Charon.SessionStore.RedisStore` is used).
+
+    ## Usage
+
+        # config
+        config :my_app, :charon,
+          token_signature_cache_module: Charon.TokenPlugs.SigVerifyCache.RedisCache,
+          ...
+
+        # supervision tree (if not already started via RedisStore)
+        children = [
+          Charon.SessionStore.RedisStore.ConnectionPool
+        ]
+    """
+
+    @behaviour Charon.TokenPlugs.SigVerifyCache.Behaviour
+
+    alias Charon.SessionStore.RedisStore.RedisClient
+
+    @impl true
+    def get(token_hash, _config) do
+      case RedisClient.command(["GET", key(token_hash)]) do
+        {:ok, <<serialized::binary>>} -> {:hit, :erlang.binary_to_term(serialized)}
+        _ -> :miss
+      end
+    end
+
+    @impl true
+    def put(token_hash, value, exp, _config) do
+      RedisClient.command(["SET", key(token_hash), :erlang.term_to_binary(value), "EXAT", exp])
+      :ok
+    end
+
+    @compile {:inline, key: 1}
+    defp key(token_hash), do: ["charon:tc:", Base.url_encode64(token_hash, padding: false)]
+  end
+end

--- a/test/charon/token_plugs/sig_verify_cache/ets_cache_test.exs
+++ b/test/charon/token_plugs/sig_verify_cache/ets_cache_test.exs
@@ -1,0 +1,77 @@
+defmodule Charon.TokenPlugs.SigVerifyCache.EtsCacheTest do
+  use ExUnit.Case, async: false
+  alias Charon.TokenPlugs.SigVerifyCache.EtsCache
+
+  @table EtsCache
+  @config TestApp.Charon.get()
+
+  setup do
+    start_supervised!(EtsCache)
+    :ok
+  end
+
+  describe "get/2" do
+    test "returns :miss when key not found" do
+      assert :miss = EtsCache.get(:crypto.hash(:sha256, "unknown_token"), @config)
+    end
+
+    test "returns {:hit, value} for a cached, non-expired success" do
+      hash = :crypto.hash(:sha256, "my_token")
+      value = {:ok, %{"sub" => 1}}
+      EtsCache.put(hash, value, System.os_time(:second) + 3600, @config)
+
+      assert {:hit, ^value} = EtsCache.get(hash, @config)
+    end
+
+    test "returns {:hit, value} for a cached, non-expired failure" do
+      hash = :crypto.hash(:sha256, "invalid_token")
+      value = {:error, "invalid signature"}
+      EtsCache.put(hash, value, System.os_time(:second) + 3600, @config)
+
+      assert {:hit, ^value} = EtsCache.get(hash, @config)
+    end
+
+    test "returns :miss for an expired entry" do
+      hash = :crypto.hash(:sha256, "expired_token")
+      EtsCache.put(hash, {:ok, %{"sub" => 1}}, System.os_time(:second) - 1, @config)
+
+      assert :miss = EtsCache.get(hash, @config)
+    end
+  end
+
+  describe "put/4" do
+    test "stores a verification result keyed by token hash" do
+      hash = :crypto.hash(:sha256, "some_token")
+      value = {:ok, %{"sub" => 42}}
+      exp = System.os_time(:second) + 600
+
+      assert :ok = EtsCache.put(hash, value, exp, @config)
+      assert {:hit, ^value} = EtsCache.get(hash, @config)
+    end
+
+    test "overwrites an existing entry" do
+      hash = :crypto.hash(:sha256, "overwrite_token")
+      exp = System.os_time(:second) + 600
+
+      EtsCache.put(hash, {:ok, %{"sub" => 1}}, exp, @config)
+      EtsCache.put(hash, {:ok, %{"sub" => 2}}, exp, @config)
+
+      assert {:hit, {:ok, %{"sub" => 2}}} = EtsCache.get(hash, @config)
+    end
+  end
+
+  describe "cleanup" do
+    test "removes expired entries on cleanup message" do
+      hash = :crypto.hash(:sha256, "cleanup_token")
+      EtsCache.put(hash, {:ok, %{}}, System.os_time(:second) - 1, @config)
+
+      # Trigger a cleanup manually by sending the message to the GenServer
+      pid = Process.whereis(EtsCache)
+      send(pid, :cleanup)
+      # Allow the GenServer to process the message
+      :sys.get_state(pid)
+
+      assert :ets.lookup(@table, hash) == []
+    end
+  end
+end

--- a/test/charon/token_plugs/sig_verify_cache/redis_cache_test.exs
+++ b/test/charon/token_plugs/sig_verify_cache/redis_cache_test.exs
@@ -1,0 +1,68 @@
+defmodule Charon.TokenPlugs.SigVerifyCache.RedisCacheTest do
+  use ExUnit.Case, async: false
+  alias Charon.TokenPlugs.SigVerifyCache.RedisCache
+  alias Charon.SessionStore.RedisStore.{ConnectionPool, RedisClient}
+
+  @config TestApp.Charon.get()
+
+  setup_all do
+    redix_opts = [host: System.get_env("REDIS_HOSTNAME", "localhost"), database: 15]
+    start_supervised!({ConnectionPool, redix_opts: redix_opts})
+    :ok
+  end
+
+  setup do
+    RedisClient.command(~w(FLUSHDB))
+    :ok
+  end
+
+  describe "get/2" do
+    test "returns :miss when key not found" do
+      assert :miss = RedisCache.get(:crypto.hash(:sha256, "unknown_token"), @config)
+    end
+
+    test "returns {:hit, value} for a cached, non-expired success" do
+      hash = :crypto.hash(:sha256, "my_token")
+      value = {:ok, %{"sub" => 1}}
+      RedisCache.put(hash, value, System.os_time(:second) + 3600, @config)
+
+      assert {:hit, ^value} = RedisCache.get(hash, @config)
+    end
+
+    test "returns {:hit, value} for a cached, non-expired failure" do
+      hash = :crypto.hash(:sha256, "invalid_token")
+      value = {:error, "invalid signature"}
+      RedisCache.put(hash, value, System.os_time(:second) + 3600, @config)
+
+      assert {:hit, ^value} = RedisCache.get(hash, @config)
+    end
+
+    test "returns :miss for an expired entry" do
+      hash = :crypto.hash(:sha256, "expired_token")
+      # exp in the past — Redis will immediately treat the key as expired/gone
+      RedisCache.put(hash, {:ok, %{"sub" => 1}}, System.os_time(:second) - 1, @config)
+
+      assert :miss = RedisCache.get(hash, @config)
+    end
+  end
+
+  describe "put/4" do
+    test "stores a verification result keyed by token hash" do
+      hash = :crypto.hash(:sha256, "some_token")
+      value = {:ok, %{"sub" => 42}}
+
+      assert :ok = RedisCache.put(hash, value, System.os_time(:second) + 600, @config)
+      assert {:hit, ^value} = RedisCache.get(hash, @config)
+    end
+
+    test "overwrites an existing entry" do
+      hash = :crypto.hash(:sha256, "overwrite_token")
+      exp = System.os_time(:second) + 600
+
+      RedisCache.put(hash, {:ok, %{"sub" => 1}}, exp, @config)
+      RedisCache.put(hash, {:ok, %{"sub" => 2}}, exp, @config)
+
+      assert {:hit, {:ok, %{"sub" => 2}}} = RedisCache.get(hash, @config)
+    end
+  end
+end

--- a/test/charon/token_plugs_unit_test.exs
+++ b/test/charon/token_plugs_unit_test.exs
@@ -315,6 +315,95 @@ defmodule Charon.TokenPlugsTest do
     end
   end
 
+  defmodule SigVerifyCacheMock do
+    use Agent
+    @behaviour Charon.TokenPlugs.SigVerifyCache.Behaviour
+
+    def start_link(_), do: Agent.start_link(fn -> %{} end, name: __MODULE__)
+
+    @impl true
+    def get(token_hash, _config), do: Agent.get(__MODULE__, &Map.get(&1, token_hash, :miss))
+
+    @impl true
+    def put(token_hash, payload, _exp, _config) do
+      Agent.update(__MODULE__, &Map.put(&1, token_hash, {:hit, payload}))
+    end
+  end
+
+  @cache_config %{
+    TestApp.Charon.get()
+    | token_signature_cache_module: SigVerifyCacheMock
+  }
+
+  describe "verify_token_signature/2 with caching enabled" do
+    setup do
+      start_supervised!(SigVerifyCacheMock)
+      :ok
+    end
+
+    test "verifies valid token signature on cache miss" do
+      token = sign(%{"msg" => "hurray!"})
+      conn = conn() |> set_token(token) |> verify_token_signature(@cache_config)
+      assert %{"msg" => "hurray!"} = Internal.get_private(conn, @bearer_token_payload)
+    end
+
+    test "reuses cached payload on cache hit" do
+      token = sign(%{"msg" => "cached!"})
+      conn() |> set_token(token) |> verify_token_signature(@cache_config)
+
+      conn = conn() |> set_token(token) |> verify_token_signature(@cache_config)
+      assert %{"msg" => "cached!"} = Internal.get_private(conn, @bearer_token_payload)
+    end
+
+    test "rejects invalid token signature on cache miss" do
+      token = sign(%{"msg" => "hurray!"})
+      conn = conn() |> set_token(token <> "boom") |> verify_token_signature(@cache_config)
+      assert nil == Internal.get_private(conn, @bearer_token_payload)
+      assert "bearer token signature invalid" == Utils.get_auth_error(conn)
+    end
+
+    test "returns error when bearer token not found" do
+      conn = conn() |> verify_token_signature(@cache_config)
+      assert "bearer token not found" == Utils.get_auth_error(conn)
+    end
+
+    test "short-circuits when auth error already set" do
+      conn =
+        conn()
+        |> set_auth_error("previous error")
+        |> set_token(sign(%{}))
+        |> verify_token_signature(@cache_config)
+
+      assert "previous error" == Utils.get_auth_error(conn)
+    end
+
+    test "caches successful verification" do
+      token = sign(%{})
+      hash = :crypto.hash(:sha256, token)
+
+      conn() |> set_token(token) |> verify_token_signature(@cache_config)
+
+      assert {:hit, {:ok, _}} = SigVerifyCacheMock.get(hash, @cache_config)
+    end
+
+    test "caches failed verification" do
+      token = sign(%{}) <> "boom"
+      hash = :crypto.hash(:sha256, token)
+
+      conn() |> set_token(token) |> verify_token_signature(@cache_config)
+
+      assert {:hit, {:error, _}} = SigVerifyCacheMock.get(hash, @cache_config)
+    end
+
+    test "returns error from cache on repeated invalid token" do
+      token = sign(%{}) <> "boom"
+      conn() |> set_token(token) |> verify_token_signature(@cache_config)
+
+      conn = conn() |> set_token(token) |> verify_token_signature(@cache_config)
+      assert "bearer token signature invalid" == Utils.get_auth_error(conn)
+    end
+  end
+
   describe "verify_token_nbf_claim/2" do
     test "accepts token with valid nbf claim" do
       conn = conn() |> set_token_payload(%{"nbf" => Internal.now()})


### PR DESCRIPTION
Adds a caching mechanism to token signature verification. Useful only for asymmetrically signed tokens (EdDSA). The caching is opt-in and disabled by default. Both a local ETS and a shared-between-nodes Redis-based implementation have been added, and a behaviour for lib users to build their own implementations on.

Closes #83.